### PR TITLE
adding explicit platform support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,15 +3,21 @@
 import PackageDescription
 
 let package = Package(
-  name: "xctest-dynamic-overlay",
-  products: [
-    .library(name: "XCTestDynamicOverlay", targets: ["XCTestDynamicOverlay"])
-  ],
-  targets: [
-    .target(name: "XCTestDynamicOverlay"),
-    .testTarget(
-      name: "XCTestDynamicOverlayTests",
-      dependencies: ["XCTestDynamicOverlay"]
-    ),
-  ]
+    name: "xctest-dynamic-overlay",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15),
+        .tvOS(.v13),
+        .watchOS(.v6),
+    ],
+    products: [
+        .library(name: "XCTestDynamicOverlay", targets: ["XCTestDynamicOverlay"])
+    ],
+    targets: [
+        .target(name: "XCTestDynamicOverlay"),
+        .testTarget(
+            name: "XCTestDynamicOverlayTests",
+            dependencies: ["XCTestDynamicOverlay"]
+        ),
+    ]
 )


### PR DESCRIPTION
Noticed that this package's lack of the explicit platform support while archiving, with Xcode 13 beta 5, fails