### PR TITLE
Fix compile error Swift 6/Linux

### DIFF
--- a/Sources/IssueReporting/Internal/Warn.swift
+++ b/Sources/IssueReporting/Internal/Warn.swift
@@ -1,4 +1,4 @@
-import Foundation
+@preconcurrency import Foundation
 
 #if canImport(WinSDK)
   import WinSDK

--- a/Sources/IssueReporting/Internal/Warn.swift
+++ b/Sources/IssueReporting/Internal/Warn.swift
@@ -1,4 +1,8 @@
+#if os(Linux)
 @preconcurrency import Foundation
+#else
+import Foundation
+#endif
 
 #if canImport(WinSDK)
   import WinSDK


### PR DESCRIPTION
Fix compile error on Linux:

```
❯ docker run --rm -v $PWD:/host -w /host swiftlang/swift@sha256:c0ba23ba9871be0552d48c5e98f363bf606858aedca11bf557bc0adde12bbc60 swift build
...
/host/Sources/IssueReporting/Internal/Warn.swift:9:25: error: reference to var 'stderr' is not concurrency-safe because it involves shared mutable state
 7 | @usableFromInline
 8 | func printError(_ message: String) {
 9 |   fputs("\(message)\n", stderr)
   |                         `- error: reference to var 'stderr' is not concurrency-safe because it involves shared mutable state
10 | }
11 | 

SwiftGlibc.stderr:1:12: note: var declared here
1 | public var stderr: UnsafeMutablePointer<FILE>!
  |            `- note: var declared here
```

`swiftlang/swift@sha256:c0ba23ba9871be0552d48c5e98f363bf606858aedca11bf557bc0adde12bbc60` is

```
################################################################
#                                                              #
# Swift Nightly Docker Image                                   #
# Tag: swift-6.0-DEVELOPMENT-SNAPSHOT-2024-07-07-a             #
#                                                              #
################################################################
```

NB: We've seen some discrepancies in concurrency errors between Linux and macOS (and also the nightlies are ahead of the Xcode betas). This error might be temporary but chances are it has to do with Foundation on Linux being different.