### PR TITLE
Fix for backwards compatibility of package name.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@
 import PackageDescription
 
 let package = Package(
+  // NB: Keep this for backwards compatibility. Will rename to 'swift-issue-reporting' in 2.0.
   name: "xctest-dynamic-overlay",
   platforms: [
     .iOS(.v13),

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let package = Package(
-  name: "swift-issue-reporting",
+  name: "xctest-dynamic-overlay",
   platforms: [
     .iOS(.v13),
     .macOS(.v10_15),


### PR DESCRIPTION
Our recent release introducing IssueReporting caused an unintended breakage due to the change of the package name. We can revert that change and save it for a future 2.0 release.