### PR TITLE
Rename package name in Package@swift-6.0.swift to match Package.swift.

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let package = Package(
-  name: "swift-issue-reporting",
+  name: "xctest-dynamic-overlay",
   platforms: [
     .iOS(.v13),
     .macOS(.v10_15),


### PR DESCRIPTION
Apply the fix from https://github.com/pointfreeco/swift-issue-reporting/pull/97 to `Package@swift-6.0.swift` as well.