### PR TITLE
Make Test compatible with Swift 5.10 and below (#104)

### DIFF
--- a/Sources/IssueReporting/Internal/SwiftTesting.swift
+++ b/Sources/IssueReporting/Internal/SwiftTesting.swift
@@ -361,14 +361,22 @@ func _currentTestIsNotNil() -> Bool {
     private var displayName: String?
     private var traits: [any Trait]
     private var sourceLocation: SourceLocation
+    #if swift(>=5.10)
     private var containingTypeInfo: TypeInfo?
+    #else
+    private var containingType: Any.Type?
+    #endif
     private var xcTestCompatibleSelector: __XCTestCompatibleSelector?
+    #if swift(>=6)
     fileprivate enum TestCasesState: @unchecked Sendable {
       case unevaluated(_ function: @Sendable () async throws -> AnySequence<Test.Case>)
       case evaluated(_ testCases: AnySequence<Test.Case>)
       case failed(_ error: any Error)
     }
     fileprivate var testCasesState: TestCasesState?
+    #else
+    private var _testCases: UncheckedSendable<AnySequence<Test.Case>>?
+    #endif
     private var parameters: [Parameter]?
     private struct Parameter: Sendable {
       var index: Int
@@ -376,7 +384,9 @@ func _currentTestIsNotNil() -> Bool {
       var secondName: String?
       var typeInfo: TypeInfo
     }
+    #if swift(>=5.10)
     private var isSynthesized = false
+    #endif
   }
 #endif
 


### PR DESCRIPTION
In order to resolve the crash described in #104, IssueReporting.Test has been made compatible with Swift 5.10 and below.

I have confirmed that the test does not crash on Swift5.9/5.10.

I tested the following versions.

Swift5.9: swift-testing0.5.1
Swift5.10: swift-testing0.7.0