### PR TITLE
Implement public initializer for UnimplementedFailure

### DIFF
--- a/Sources/IssueReporting/Unimplemented.swift
+++ b/Sources/IssueReporting/Unimplemented.swift
@@ -174,6 +174,10 @@ public func unimplemented<Result>(
 /// An error thrown from throwing `unimplemented` closures.
 public struct UnimplementedFailure: Error {
   public let description: String
+
+  public init(description: String) {
+    self.description = description
+  }
 }
 
 package func _fail(


### PR DESCRIPTION
In order to be able to construct and throw UnimplementedFailure as alternative solution to `unimplemented` placeholder in throws functions and closures. 
```swift
unimplemented("\(Self.self).count is unimplemented")
throw UnimplementedFailure(description: "\(Self.self).count is unimplemented")
```