### PR TITLE
Underscore issue reporter type names

### DIFF
--- a/Sources/IssueReporting/Documentation.docc/Extensions/IssueReporter.breakpoint.md
+++ b/Sources/IssueReporting/Documentation.docc/Extensions/IssueReporter.breakpoint.md
@@ -1,7 +1,0 @@
-# ``IssueReporting/IssueReporter/breakpoint``
-
-## Topics
-
-### Reporter
-
-- ``BreakpointReporter``

--- a/Sources/IssueReporting/Documentation.docc/Extensions/IssueReporter.fatalError.md
+++ b/Sources/IssueReporting/Documentation.docc/Extensions/IssueReporter.fatalError.md
@@ -1,7 +1,0 @@
-# ``IssueReporting/IssueReporter/fatalError``
-
-## Topics
-
-### Reporter
-
-- ``FatalErrorReporter``

--- a/Sources/IssueReporting/Documentation.docc/Extensions/IssueReporter.runtimeWarning.md
+++ b/Sources/IssueReporting/Documentation.docc/Extensions/IssueReporter.runtimeWarning.md
@@ -1,7 +1,0 @@
-# ``IssueReporting/IssueReporter/runtimeWarning``
-
-## Topics
-
-### Reporter
-
-- ``RuntimeWarningReporter``

--- a/Sources/IssueReporting/Internal/Deprecations.swift
+++ b/Sources/IssueReporting/Internal/Deprecations.swift
@@ -1,0 +1,10 @@
+// NB: Deprecated after 1.2.2
+
+@available(*, unavailable, renamed: "_FatalErrorReporter")
+public typealias BreakpointReporter = _BreakpointReporter
+
+@available(*, unavailable, renamed: "_FatalErrorReporter")
+public typealias FatalErrorReporter = _FatalErrorReporter
+
+@available(*, unavailable, renamed: "_FatalErrorReporter")
+public typealias RuntimeWarningReporter = _RuntimeWarningReporter

--- a/Sources/IssueReporting/Internal/Deprecations.swift
+++ b/Sources/IssueReporting/Internal/Deprecations.swift
@@ -1,10 +1,12 @@
 // NB: Deprecated after 1.2.2
 
-@available(*, unavailable, renamed: "_FatalErrorReporter")
-public typealias BreakpointReporter = _BreakpointReporter
+#if canImport(Darwin)
+  @available(*, unavailable, renamed: "_BreakpointReporter")
+  public typealias BreakpointReporter = _BreakpointReporter
+#endif
 
 @available(*, unavailable, renamed: "_FatalErrorReporter")
 public typealias FatalErrorReporter = _FatalErrorReporter
 
-@available(*, unavailable, renamed: "_FatalErrorReporter")
+@available(*, unavailable, renamed: "_RuntimeWarningReporter")
 public typealias RuntimeWarningReporter = _RuntimeWarningReporter

--- a/Sources/IssueReporting/IssueReporters/BreakpointReporter.swift
+++ b/Sources/IssueReporting/IssueReporters/BreakpointReporter.swift
@@ -1,7 +1,7 @@
 #if canImport(Darwin)
   import Darwin
 
-  extension IssueReporter where Self == BreakpointReporter {
+  extension IssueReporter where Self == _BreakpointReporter {
     /// An issue reporter that pauses program execution when a debugger is attached.
     ///
     /// Logs a warning to the console and raises `SIGTRAP` when an issue is received.
@@ -12,7 +12,7 @@
   /// attached.
   ///
   /// Use ``IssueReporter/breakpoint`` to create one of these values.
-  public struct BreakpointReporter: IssueReporter {
+  public struct _BreakpointReporter: IssueReporter {
     public func reportIssue(
       _ message: @autoclosure () -> String?,
       fileID: StaticString,

--- a/Sources/IssueReporting/IssueReporters/FatalErrorReporter.swift
+++ b/Sources/IssueReporting/IssueReporters/FatalErrorReporter.swift
@@ -1,4 +1,4 @@
-extension IssueReporter where Self == FatalErrorReporter {
+extension IssueReporter where Self == _FatalErrorReporter {
   /// An issue reporter that terminates program execution.
   ///
   /// Calls Swift's `fatalError` function when an issue is received.
@@ -8,7 +8,7 @@ extension IssueReporter where Self == FatalErrorReporter {
 /// A type representing an issue reporter that terminates program execution.
 ///
 /// Use ``IssueReporter/fatalError`` to create one of these values.
-public struct FatalErrorReporter: IssueReporter {
+public struct _FatalErrorReporter: IssueReporter {
   public func reportIssue(
     _ message: @autoclosure () -> String?,
     fileID: StaticString,

--- a/Sources/IssueReporting/IssueReporters/RuntimeWarningReporter.swift
+++ b/Sources/IssueReporting/IssueReporters/RuntimeWarningReporter.swift
@@ -4,7 +4,7 @@ import Foundation
   import os
 #endif
 
-extension IssueReporter where Self == RuntimeWarningReporter {
+extension IssueReporter where Self == _RuntimeWarningReporter {
   /// An issue reporter that emits "purple" runtime warnings to Xcode and logs fault-level messages
   /// to the console.
   ///
@@ -22,7 +22,7 @@ extension IssueReporter where Self == RuntimeWarningReporter {
 /// fault-level messages to the console.
 ///
 /// Use ``IssueReporter/runtimeWarning`` to create one of these values.
-public struct RuntimeWarningReporter: IssueReporter {
+public struct _RuntimeWarningReporter: IssueReporter {
   #if canImport(os)
     @UncheckedSendable
     #if canImport(Darwin)


### PR DESCRIPTION
The big issue here is that `FatalErrorReporter` takes precedence in autocomplete over Swift's `fatalError` and is quite an annoyance when importing our library.

These probably should have never been prominent when the preferred spelling is `.fatalError`, etc.

This is a breaking bug fix change with fix-its.