### PR TITLE
Fix regression: don't `fatalError` eagerly when calling deprecated `unimplemented` endpoints

### DIFF
--- a/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
@@ -277,7 +277,6 @@ public func unimplemented<Result>(
   }
 }
 
-@_disfavoredOverload
 @available(*, deprecated, renamed: "unimplemented(_:placeholder:)")
 public func unimplemented<each Argument, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -104,6 +104,9 @@ struct User { let id: UUID }
 @MainActor let f05: (String, Int, Double, [Int], User) -> Int = unimplemented(
   "f05", placeholder: 42)
 
+let fm00: () -> Int = unimplemented("fm00")
+let fm01: @MainActor () -> Int = unimplemented("fm01")
+
 @available(*, deprecated)
 private struct Autoclosing {
   init(

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -104,8 +104,11 @@ struct User { let id: UUID }
 @MainActor let f05: (String, Int, Double, [Int], User) -> Int = unimplemented(
   "f05", placeholder: 42)
 
-let fm00: () -> Int = unimplemented("fm00")
-let fm01: @MainActor () -> Int = unimplemented("fm01")
+@available(*, deprecated)
+@MainActor let fm00: () -> Int = unimplemented("fm00")
+
+@available(*, deprecated)
+@MainActor let fm01: @MainActor () -> Int = unimplemented("fm01")
 
 @available(*, deprecated)
 private struct Autoclosing {

--- a/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
@@ -2,10 +2,12 @@
   import XCTest
 
   final class UnimplementedTests: XCTestCase {
-    
+
+    @available(*, deprecated)
+    @MainActor
     func testXCTReferencingUnimplementedClosureDoesNotEvaluateIt() async throws {
-      _ = fm00;
-      _ = fm01;
+      _ = fm00
+      _ = fm01
     }
 
     func testXCTFailShouldFail() async throws {

--- a/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/UnimplementedTests.swift
@@ -2,6 +2,12 @@
   import XCTest
 
   final class UnimplementedTests: XCTestCase {
+    
+    func testXCTReferencingUnimplementedClosureDoesNotEvaluateIt() async throws {
+      _ = fm00;
+      _ = fm01;
+    }
+
     func testXCTFailShouldFail() async throws {
       _ = XCTExpectFailure {
         f00()


### PR DESCRIPTION
Fixes #113.