### PR TITLE
Update `reportIssue` to call `Issue.record`

### DIFF
--- a/Sources/IssueReporting/Internal/SwiftTesting.swift
+++ b/Sources/IssueReporting/Internal/SwiftTesting.swift
@@ -16,41 +16,21 @@ func _recordIssue(
   else {
     #if DEBUG
       guard
-        let fromSyntaxNode = unsafeBitCast(
-          symbol: "$s7Testing12__ExpressionV16__fromSyntaxNodeyACSSFZ",
+        let record = unsafeBitCast(
+          symbol: "$s7Testing5IssueV6record_14sourceLocationAcA7CommentVSg_AA06SourceE0VtFZ",
           in: "Testing",
-          to: (@convention(thin) (String) -> __Expression).self
-        ),
-        let checkValue = unsafeBitCast(
-          symbol: """
-            $s7Testing12__checkValue_10expression0D25WithCapturedRuntimeValues26mismatchedErrorDesc\
-            ription10difference8comments10isRequired14sourceLocations6ResultOyyts0J0_pGSb_AA12__Exp\
-            ressionVAOSgyXKSSSgyXKAQyXKSayAA7CommentVGyXKSbAA06SourceQ0VtF
-            """,
-          in: "Testing",
-          to: (@convention(thin) (
-            Bool,
-            __Expression,
-            @autoclosure () -> __Expression?,
-            @autoclosure () -> String?,
-            @autoclosure () -> String?,
-            @autoclosure () -> [Any],
-            Bool,
-            SourceLocation
-          ) -> Result<Void, any Error>)
-          .self
+          to: (@convention(thin) (Any?, SourceLocation) -> Issue).self
         )
       else { return }
 
-      let syntaxNode = fromSyntaxNode(message ?? "")
-      _ = checkValue(
-        false,
-        syntaxNode,
-        nil,
-        nil,
-        nil,
-        [],
-        false,
+      var comment: Any?
+      if let message {
+        var c = UnsafeMutablePointer<Comment>.allocate(capacity: 1).pointee
+        c.rawValue = message
+        comment = c
+      }
+      _ = record(
+        comment,
         SourceLocation(fileID: fileID, _filePath: filePath, line: line, column: column)
       )
     #else
@@ -87,7 +67,7 @@ func _recordError(
             $s7Testing5IssueV6record__14sourceLocationACs5Error_p_AA7CommentVSgAA06SourceE0VtFZ
             """,
           in: "Testing",
-          to: (@convention(thin) (any Error, Any?, SourceLocation) -> Any).self
+          to: (@convention(thin) (any Error, Any?, SourceLocation) -> Issue).self
         )
       else { return }
 
@@ -310,19 +290,9 @@ func _currentTestIsNotNil() -> Bool {
     var runtimeValue: Value?
   }
 
-  private struct TypeInfo: Sendable {
-    enum _Kind: Sendable {
-      case type(_ type: Any.Type)
-      case nameOnly(fullyQualifiedComponents: [String], unqualified: String, mangled: String?)
-    }
-    var _kind: _Kind
-  }
-
-  private struct SourceLocation: Sendable {
-    var fileID: String
-    var _filePath: String
-    var line: Int
-    var column: Int
+  private struct Backtrace: Sendable {
+    typealias Address = UInt64
+    var addresses: [Address]
   }
 
   private struct Comment: RawRepresentable, Sendable {
@@ -342,7 +312,48 @@ func _currentTestIsNotNil() -> Bool {
     var kind: Kind?
   }
 
-  private protocol Trait: Sendable {}
+  private struct Confirmation: Sendable {
+    protocol ExpectedCount: Sendable, RangeExpression<Int> {}
+  }
+
+  private struct Expectation: Sendable {
+    var evaluatedExpression: __Expression
+    var mismatchedErrorDescription: String?
+    var differenceDescription: String?
+    var mismatchedExitConditionDescription: String?
+    var isPassing: Bool
+    var isRequired: Bool
+    var sourceLocation: SourceLocation
+  }
+
+  private struct Issue: Sendable {
+    enum Kind: Sendable {
+      case unconditional
+      indirect case expectationFailed(_ expectation: Expectation)
+      indirect case confirmationMiscounted(actual: Int, expected: Int)
+      indirect case confirmationOutOfRange(actual: Int, expected: any Confirmation.ExpectedCount)
+      indirect case errorCaught(_ error: any Error)
+      indirect case timeLimitExceeded(timeLimitComponents: (seconds: Int64, attoseconds: Int64))
+      case knownIssueNotRecorded
+      case apiMisused
+      case system
+    }
+    var kind: Kind
+    var comments: [Comment]
+    var sourceContext: SourceContext
+  }
+
+  private struct SourceContext: Sendable {
+    var backtrace: Backtrace?
+    var sourceLocation: SourceLocation?
+  }
+
+  private struct SourceLocation: Sendable {
+    var fileID: String
+    var _filePath: String
+    var line: Int
+    var column: Int
+  }
 
   struct Test: @unchecked Sendable {
     static var current: Self? {
@@ -377,6 +388,16 @@ func _currentTestIsNotNil() -> Bool {
       var typeInfo: TypeInfo
     }
     private var isSynthesized = false
+  }
+
+  private protocol Trait: Sendable {}
+
+  private struct TypeInfo: Sendable {
+    enum _Kind: Sendable {
+      case type(_ type: Any.Type)
+      case nameOnly(fullyQualifiedComponents: [String], unqualified: String, mangled: String?)
+    }
+    var _kind: _Kind
   }
 #endif
 

--- a/Sources/IssueReportingTestSupport/SwiftTesting.swift
+++ b/Sources/IssueReportingTestSupport/SwiftTesting.swift
@@ -12,21 +12,8 @@ private func __recordIssue(
   column: Int
 ) {
   #if canImport(Testing)
-    // NB: https://github.com/apple/swift-testing/issues/490
-    // Issue.record(
-    //   message.map(Comment.init(rawValue:)),
-    //   sourceLocation: SourceLocation(
-    //     fileID: fileID,
-    //     filePath: filePath,
-    //     line: line,
-    //     column: column
-    //   )
-    // )
-    __checkValue(
-      false,
-      expression: .__fromSyntaxNode(message ?? ""),
-      comments: [],
-      isRequired: false,
+    Issue.record(
+      message.map(Comment.init(rawValue:)),
       sourceLocation: SourceLocation(
         fileID: fileID,
         filePath: filePath,
@@ -34,7 +21,6 @@ private func __recordIssue(
         column: column
       )
     )
-    .__expected()
   #endif
 }
 

--- a/Tests/IssueReportingTests/SwiftTestingTests.swift
+++ b/Tests/IssueReportingTests/SwiftTestingTests.swift
@@ -12,7 +12,7 @@
       withKnownIssue {
         reportIssue()
       } matching: { issue in
-        issue.description == "Expectation failed: "
+        issue.description == "Issue recorded"
       }
     }
 
@@ -29,7 +29,7 @@
       withKnownIssue {
         reportIssue("Something went wrong")
       } matching: { issue in
-        issue.description == "Expectation failed: Something went wrong"
+        issue.description == "Issue recorded: Something went wrong"
       }
     }
 

--- a/Tests/IssueReportingTests/UnimplementedTests.swift
+++ b/Tests/IssueReportingTests/UnimplementedTests.swift
@@ -15,7 +15,7 @@
         model.callback(42)
       } matching: { issue in
         issue.description == """
-          Expectation failed: Unimplemented …
+          Issue recorded: Unimplemented …
 
             Defined in 'Model' at:
               IssueReportingTests/UnimplementedTests.swift:\(model.line)
@@ -37,7 +37,7 @@
         model.callback()
       } matching: { issue in
         issue.description == """
-          Expectation failed: Unimplemented …
+          Issue recorded: Unimplemented …
 
             Defined in 'Model' at:
               IssueReportingTests/UnimplementedTests.swift:\(model.line)
@@ -59,7 +59,7 @@
         _ = model.callback()
       } matching: { issue in
         issue.description == """
-          Expectation failed: Unimplemented …
+          Issue recorded: Unimplemented …
 
             Defined in 'Model' at:
               IssueReportingTests/UnimplementedTests.swift:\(model.line)
@@ -81,7 +81,7 @@
         _ = try model.callback()
       } matching: { issue in
         issue.description == """
-          Expectation failed: Unimplemented …
+          Issue recorded: Unimplemented …
 
             Defined in 'Model' at:
               IssueReportingTests/UnimplementedTests.swift:\(model.line)
@@ -107,7 +107,7 @@
           _ = try model.callback()
         } matching: { issue in
           issue.description == """
-            Expectation failed: Unimplemented …
+            Issue recorded: Unimplemented …
 
               Defined in 'Model' at:
                 IssueReportingTests/UnimplementedTests.swift:\(model.line)


### PR DESCRIPTION
We should be calling to this more stable interface now that the messaging has been updated.