### PR TITLE
`unimplemented` support for typed throws

### DIFF
--- a/Sources/IssueReporting/Documentation.docc/Extensions/Unimplemented.md
+++ b/Sources/IssueReporting/Documentation.docc/Extensions/Unimplemented.md
@@ -6,6 +6,8 @@
 
 - ``unimplemented(_:fileID:filePath:function:line:column:)-2ae22``
 - ``unimplemented(_:fileID:filePath:function:line:column:)-1hsov``
+- ``unimplemented(_:throwing:fileID:filePath:function:line:column:)-4h958``
+- ``unimplemented(_:throwing:fileID:filePath:function:line:column:)-5zfy9``
 - ``unimplemented(_:placeholder:fileID:filePath:function:line:column:)-6ts5j``
 - ``unimplemented(_:placeholder:fileID:filePath:function:line:column:)-34tpp``
 

--- a/Sources/IssueReporting/Unimplemented.swift
+++ b/Sources/IssueReporting/Unimplemented.swift
@@ -73,6 +73,7 @@ public func unimplemented<each Argument, Result>(
   }
 }
 
+#if compiler(>=6)
 /// Returns a throwing closure that reports an issue and throws a given error when invoked.
 ///
 /// Useful for creating closures that need to be overridden by users of your API, and if it is
@@ -111,6 +112,7 @@ public func unimplemented<each Argument, Failure: Error, Result>(
     throw failure()
   }
 }
+#endif
 
 /// Returns an asynchronous closure that reports an issue when invoked.
 ///
@@ -188,6 +190,7 @@ public func unimplemented<each Argument, Result>(
   }
 }
 
+#if compiler(>=6)
 /// Returns a throwing, asynchronous closure that reports an issue and throws a given error when
 /// invoked.
 ///
@@ -228,6 +231,7 @@ public func unimplemented<each Argument, Failure: Error, Result>(
     throw failure()
   }
 }
+#endif
 
 @_disfavoredOverload
 public func unimplemented<Result>(

--- a/Sources/IssueReporting/Unimplemented.swift
+++ b/Sources/IssueReporting/Unimplemented.swift
@@ -73,6 +73,45 @@ public func unimplemented<each Argument, Result>(
   }
 }
 
+/// Returns a throwing closure that reports an issue and throws a given error when invoked.
+///
+/// Useful for creating closures that need to be overridden by users of your API, and if it is
+/// ever invoked without being overridden an issue will be reported. See
+/// <doc:GettingStarted#Unimplemented-closures> for more information.
+///
+/// - Parameters:
+///   - description: An optional description of the unimplemented closure.
+///   - failure: The error thrown by the unimplemented closure.
+///   - fileID: The fileID.
+///   - filePath: The filePath.
+///   - function: The function.
+///   - line: The line.
+///   - column: The column.
+/// - Returns: A throwing closure that reports an issue and throws an error when invoked.
+public func unimplemented<each Argument, Failure: Error, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  throwing failure: @autoclosure @escaping @Sendable () -> Failure,
+  fileID: StaticString = #fileID,
+  filePath: StaticString = #filePath,
+  function: StaticString = #function,
+  line: UInt = #line,
+  column: UInt = #column
+) -> @Sendable (repeat each Argument) throws(Failure) -> Result {
+  return { (argument: repeat each Argument) throws(Failure) in
+    let description = description()
+    _fail(
+      description,
+      (repeat each argument),
+      fileID: fileID,
+      filePath: filePath,
+      function: function,
+      line: line,
+      column: column
+    )
+    throw failure()
+  }
+}
+
 /// Returns an asynchronous closure that reports an issue when invoked.
 ///
 /// Useful for creating closures that need to be overridden by users of your API, and if it is
@@ -146,6 +185,47 @@ public func unimplemented<each Argument, Result>(
       column: column
     )
     throw UnimplementedFailure(description: description)
+  }
+}
+
+/// Returns a throwing, asynchronous closure that reports an issue and throws a given error when
+/// invoked.
+///
+/// Useful for creating closures that need to be overridden by users of your API, and if it is
+/// ever invoked without being overridden an issue will be reported. See
+/// <doc:GettingStarted#Unimplemented-closures> for more information.
+///
+/// - Parameters:
+///   - description: An optional description of the unimplemented closure.
+///   - failure: The error thrown by the unimplemented closure.
+///   - fileID: The fileID.
+///   - filePath: The filePath.
+///   - function: The function.
+///   - line: The line.
+///   - column: The column.
+/// - Returns: A throwing, asynchronous closure that reports an issue and throws an error when
+///   invoked.
+public func unimplemented<each Argument, Failure: Error, Result>(
+  _ description: @autoclosure @escaping @Sendable () -> String = "",
+  throwing failure: @autoclosure @escaping @Sendable () -> Failure,
+  fileID: StaticString = #fileID,
+  filePath: StaticString = #filePath,
+  function: StaticString = #function,
+  line: UInt = #line,
+  column: UInt = #column
+) -> @Sendable (repeat each Argument) async throws(Failure) -> Result {
+  return { (argument: repeat each Argument) async throws(Failure) in
+    let description = description()
+    _fail(
+      description,
+      (repeat each argument),
+      fileID: fileID,
+      filePath: filePath,
+      function: function,
+      line: line,
+      column: column
+    )
+    throw failure()
   }
 }
 


### PR DESCRIPTION
This adds `unimplemented` support for endpoints using typed throws.