### PR TITLE
Disfavor another `unimplemented` deprecation

### DIFF
--- a/Examples/ExamplesTests/SwiftTestingTests.swift
+++ b/Examples/ExamplesTests/SwiftTestingTests.swift
@@ -13,7 +13,7 @@
         withKnownIssue {
           reportIssue()
         } matching: { issue in
-          issue.description == "Expectation failed: "
+          issue.description == "Issue recorded"
         }
       }
 
@@ -21,7 +21,7 @@
         withKnownIssue {
           reportIssue("Something went wrong")
         } matching: { issue in
-          issue.description == "Expectation failed: Something went wrong"
+          issue.description == "Issue recorded: Something went wrong"
         }
       }
 

--- a/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
@@ -277,6 +277,7 @@ public func unimplemented<Result>(
   }
 }
 
+@_disfavoredOverload
 @available(*, deprecated, renamed: "unimplemented(_:placeholder:)")
 public func unimplemented<each Argument, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",

--- a/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
@@ -251,7 +251,7 @@ public var XCTCurrentTestCase: AnyObject? {
 }
 
 @_disfavoredOverload
-@available(*, deprecated, renamed: "unimplemented(_:placeholder:)")
+@available(*, unavailable, renamed: "unimplemented(_:placeholder:)")
 public func unimplemented<Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = "",
   file filePath: StaticString = #filePath,
@@ -260,21 +260,7 @@ public func unimplemented<Result>(
   line: UInt = #line,
   column: UInt = #column
 ) -> Result {
-  let description = description()
-  _fail(
-    description,
-    nil,
-    fileID: fileID,
-    filePath: filePath,
-    function: function,
-    line: line,
-    column: column
-  )
-  do {
-    return try _generatePlaceholder()
-  } catch {
-    _unimplementedFatalError(description, file: filePath, line: line)
-  }
+  fatalError()
 }
 
 @_disfavoredOverload

--- a/Tests/IssueReportingTests/UnimplementedTests.swift
+++ b/Tests/IssueReportingTests/UnimplementedTests.swift
@@ -122,5 +122,34 @@
           """
       }
     }
+
+    @MainActor
+    @Test func mainActor() throws {
+      final class Model: Sendable {
+        let line = #line + 1
+        let callback: @Sendable @MainActor () throws -> Void = IssueReporting.unimplemented()
+      }
+
+      let model = Model()
+      try withKnownIssue {
+        try withKnownIssue {
+          _ = try model.callback()
+        } matching: { issue in
+          issue.description == """
+            Issue recorded: Unimplemented …
+
+              Defined in 'Model' at:
+                IssueReportingTests/UnimplementedTests.swift:\(model.line)
+
+              Invoked with:
+                ()
+            """
+        }
+      } matching: { issue in
+        issue.description == """
+          Caught error: UnimplementedFailure(description: "")
+          """
+      }
+    }
   }
 #endif

--- a/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
+++ b/Tests/XCTestDynamicOverlayTests/TestHelpers.swift
@@ -110,12 +110,11 @@ struct User { let id: UUID }
 @available(*, deprecated)
 @MainActor let fm01: @MainActor () -> Int = unimplemented("fm01")
 
-@available(*, deprecated)
 private struct Autoclosing {
   init(
-    _: @autoclosure () -> Int = unimplemented(),
-    _: @autoclosure () async -> Int = unimplemented(),
-    _: @autoclosure () throws -> Int = unimplemented(),
-    _: @autoclosure () async throws -> Int = unimplemented()
+    _: @autoclosure () -> Int = unimplemented(placeholder: 0),
+    _: @autoclosure () async -> Int = unimplemented(placeholder: 0),
+    _: @autoclosure () throws -> Int = unimplemented(placeholder: 0),
+    _: @autoclosure () async throws -> Int = unimplemented(placeholder: 0)
   ) async {}
 }


### PR DESCRIPTION
When XCTestDynamicOverlay and IssueReporting are both imported into a file, the deprecated version takes precedence in certain situations, triggering a warning. This PR should address.