### PR TITLE
fix issue with linux build failing due to missing testing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "149fbef45ea8fe3cd64531e086463b254f23bc4cffc4f1af2b58697d4fa2d4b9",
   "pins" : [
     {
       "identity" : "carton",
@@ -64,12 +65,30 @@
       }
     },
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "515f79b522918f83483068d99c68daeb5116342d",
+        "version" : "600.0.0-prerelease-2024-09-04"
+      }
+    },
+    {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
         "revision" : "6a9e38e7bd22a3b8ba80bddf395623cf68f57807",
         "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-testing",
+      "state" : {
+        "revision" : "c55848b2aa4b29a4df542b235dfdd792a6fbe341",
+        "version" : "0.12.0"
       }
     },
     {
@@ -82,5 +101,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -15,6 +15,11 @@ let package = Package(
     .library(name: "IssueReportingTestSupport", targets: ["IssueReportingTestSupport"]),
     .library(name: "XCTestDynamicOverlay", targets: ["XCTestDynamicOverlay"]),
   ],
+  dependencies: [
+    // On Apple platforms this is included but not including it will not work on other platforms
+    // see section https://swiftpackageindex.com/swiftlang/swift-testing/main/documentation/testing/temporarygettingstarted#Adding-the-testing-library-as-a-dependency
+    .package(url: "https://github.com/apple/swift-testing", from: "0.11.0")
+  ],
   targets: [
     .target(
       name: "IssueReporting"
@@ -27,7 +32,8 @@ let package = Package(
       ]
     ),
     .target(
-      name: "IssueReportingTestSupport"
+      name: "IssueReportingTestSupport",
+      dependencies: [.product(name: "Testing", package: "swift-testing")]
     ),
     .target(
       name: "XCTestDynamicOverlay",
@@ -43,12 +49,6 @@ let package = Package(
   ],
   swiftLanguageVersions: [.v6]
 )
-
-#if os(Linux) || os(Windows)
-  package.dependencies.append(
-    .package(url: "https://github.com/apple/swift-testing", from: "0.11.0")
-  )
-#endif
 
 #if os(macOS)
   package.dependencies.append(contentsOf: [


### PR DESCRIPTION
Here's a more polished and professional version of your description that would be suitable for a pull request:

---

### Description of the Issue

On a Linux build where I use `case-paths`, I encountered an issue that required me to add the `swift-testing` dependency explicitly. While testing on macOS, I found that this did not conflict with the existing Xcode setup, but to ensure compatibility across both platforms, it seems safest to add the dependency explicitly.

This issue arose because I use `swift-testing` in the project, and while it enabled me to run tests on Linux, it caused the build to fail when testing code that uses `case-paths`. The failure occurred because `case-paths` could not import `Testing`. I had been using `Testing` for running tests but had not listed it as a dependency in the target that uses it.

### Solution

To resolve this, I have added `swift-testing` as an explicit dependency for the target using `case-paths`. This approach ensures the tests run correctly on Linux while maintaining compatibility with macOS. Since the dependency can only be added if it’s listed in the package, I opted to remove the `#if` condition to avoid build failures on macOS.

---

By explicitly including the `swift-testing` dependency, this change ensures a smoother experience for both Linux and macOS builds, eliminating issues related to missing dependencies during testing.

--- 

This more polished version will help present your change more clearly when submitting a pull request. Let me know if you need any adjustments!

## The build fail on linux

<img width="785" alt="Screenshot 2024-09-06 at 12 51 33" src="https://github.com/user-attachments/assets/873e5290-bbdf-4430-b180-5948a3c29d7f">
