### PR TITLE
Make TestContext Equatable.

### DIFF
--- a/Sources/IssueReporting/TestContext.swift
+++ b/Sources/IssueReporting/TestContext.swift
@@ -40,16 +40,16 @@ public enum TestContext: Equatable {
   public struct Testing: Equatable {
     public let test: Test
 
-    public struct Test: Hashable, Identifiable, Sendable {
+    public struct Test: Equatable, Hashable, Identifiable, Sendable {
       public let id: ID
 
-      public struct ID: Hashable, @unchecked Sendable {
+      public struct ID: Equatable, Hashable, @unchecked Sendable {
         fileprivate let rawValue: AnyHashable
       }
     }
   }
 
-  @available(*, deprecated, message: "Test for '.swiftTesting' using pattern matching, instead.")
+  @available(*, deprecated, message: "Test using pattern matching, instead.")
   public static func == (lhs: Self, rhs: Self) -> Bool {
     switch (lhs, rhs) {
     case (.swiftTesting(nil), .swiftTesting),
@@ -63,7 +63,10 @@ public enum TestContext: Equatable {
     }
   }
 
-  @available(*, deprecated, message: "Test for '.swiftTesting' using pattern matching, instead.")
+  @available(
+    *, deprecated,
+    message: "Test for '.swiftTesting' using pattern matching or 'isSwiftTesting', instead."
+  )
   public static var swiftTesting: Self {
     .swiftTesting(nil)
   }

--- a/Sources/IssueReporting/TestContext.swift
+++ b/Sources/IssueReporting/TestContext.swift
@@ -60,7 +60,9 @@ extension TestContext: Equatable {
       return true
     case (.swiftTesting(let lhs), .swiftTesting(let rhs)):
       return lhs == rhs
-    default:
+    case (.swiftTesting, .xcTest), (.xcTest, .swiftTesting):
+      return false
+    @unknown default:
       return false
     }
   }

--- a/Sources/IssueReporting/TestContext.swift
+++ b/Sources/IssueReporting/TestContext.swift
@@ -1,6 +1,6 @@
 /// A type representing the context in which a test is being run, _i.e._ either in Swift's native
 /// Testing framework, or Xcode's XCTest framework.
-public enum TestContext {
+public enum TestContext: Equatable {
   /// The Swift Testing framework.
   case swiftTesting(Testing?)
 
@@ -29,7 +29,7 @@ public enum TestContext {
       return .xcTest
     }
   }
-  
+
   /// Determines if the test context is Swift's native Testing framework.
   public var isSwiftTesting: Bool {
     guard case .swiftTesting = self
@@ -48,10 +48,8 @@ public enum TestContext {
       }
     }
   }
-}
 
-@available(*, deprecated, message: "Test for '.swiftTesting' using pattern matching, instead.")
-extension TestContext: Equatable {
+  @available(*, deprecated, message: "Test for '.swiftTesting' using pattern matching, instead.")
   public static func == (lhs: Self, rhs: Self) -> Bool {
     switch (lhs, rhs) {
     case (.swiftTesting(nil), .swiftTesting),
@@ -62,11 +60,10 @@ extension TestContext: Equatable {
       return lhs == rhs
     case (.swiftTesting, .xcTest), (.xcTest, .swiftTesting):
       return false
-    @unknown default:
-      return false
     }
   }
 
+  @available(*, deprecated, message: "Test for '.swiftTesting' using pattern matching, instead.")
   public static var swiftTesting: Self {
     .swiftTesting(nil)
   }

--- a/Sources/IssueReporting/TestContext.swift
+++ b/Sources/IssueReporting/TestContext.swift
@@ -1,6 +1,6 @@
 /// A type representing the context in which a test is being run, _i.e._ either in Swift's native
 /// Testing framework, or Xcode's XCTest framework.
-public enum TestContext {
+public enum TestContext: Equatable {
   /// The Swift Testing framework.
   case swiftTesting(Testing)
 
@@ -12,8 +12,10 @@ public enum TestContext {
   /// How the test context is detected depends on the framework:
   ///
   ///   * If Swift Testing is running, _and_ this is called from the current test's task, this will
-  ///     return ``swiftTesting``. In this way, `TestContext.current == .swiftTesting` is equivalent
-  ///     to checking `Test.current != nil`, but safe to do from library and application code.
+  ///     return ``swiftTesting`` with an associated value of the current test. You can invoke
+  ///     ``isSwiftTesting`` to detect if the test is currently in the Swift Testing framework,
+  ///     which is equivalent to checking `Test.current != nil`, but safe to do from library and
+  ///     application code.
   ///
   ///   * If XCTest is running, _and_ this is called during the execution of a test _regardless_ of
   ///     task, this will return ``xcTest``.
@@ -27,8 +29,15 @@ public enum TestContext {
       return .xcTest
     }
   }
+  
+  /// Determines if the test context is Swift's native Testing framework.
+  public var isSwiftTesting: Bool {
+    guard case .swiftTesting = self
+    else { return false }
+    return true
+  }
 
-  public struct Testing {
+  public struct Testing: Equatable {
     public let test: Test
 
     public struct Test: Hashable, Identifiable, Sendable {

--- a/Sources/IssueReporting/TestContext.swift
+++ b/Sources/IssueReporting/TestContext.swift
@@ -50,12 +50,7 @@ public enum TestContext {
   }
 }
 
-extension TestContext.Testing {
-  fileprivate init(id: AnyHashable) {
-    self.init(test: Test(id: Test.ID(rawValue: id)))
-  }
-}
-
+@available(*, deprecated, message: "Test for '.swiftTesting' using pattern matching, instead.")
 extension TestContext: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     switch (lhs, rhs) {
@@ -70,8 +65,13 @@ extension TestContext: Equatable {
     }
   }
 
-  @available(*, deprecated, message: "Test for '.swiftTesting' using pattern matching, instead.")
   public static var swiftTesting: Self {
     .swiftTesting(nil)
+  }
+}
+
+extension TestContext.Testing {
+  fileprivate init(id: AnyHashable) {
+    self.init(test: Test(id: Test.ID(rawValue: id)))
   }
 }

--- a/Sources/IssueReporting/TestContext.swift
+++ b/Sources/IssueReporting/TestContext.swift
@@ -1,8 +1,8 @@
 /// A type representing the context in which a test is being run, _i.e._ either in Swift's native
 /// Testing framework, or Xcode's XCTest framework.
-public enum TestContext: Equatable {
+public enum TestContext {
   /// The Swift Testing framework.
-  case swiftTesting(Testing)
+  case swiftTesting(Testing?)
 
   /// The XCTest framework.
   case xcTest
@@ -53,5 +53,25 @@ public enum TestContext: Equatable {
 extension TestContext.Testing {
   fileprivate init(id: AnyHashable) {
     self.init(test: Test(id: Test.ID(rawValue: id)))
+  }
+}
+
+extension TestContext: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case (.swiftTesting(nil), .swiftTesting),
+      (.swiftTesting, .swiftTesting(nil)),
+      (.xcTest, .xcTest):
+      return true
+    case (.swiftTesting(let lhs), .swiftTesting(let rhs)):
+      return lhs == rhs
+    default:
+      return false
+    }
+  }
+
+  @available(*, deprecated, message: "Test for '.swiftTesting' using pattern matching, instead.")
+  public static var swiftTesting: Self {
+    .swiftTesting(nil)
   }
 }


### PR DESCRIPTION
We lost the `Equatable` conformance on `TestContext` with #125, so bringing it back.