### PR TITLE
Publicize Swift Testing's underlying Test.ID

### DIFF
--- a/Sources/IssueReporting/TestContext.swift
+++ b/Sources/IssueReporting/TestContext.swift
@@ -1,6 +1,6 @@
 /// A type representing the context in which a test is being run, _i.e._ either in Swift's native
 /// Testing framework, or Xcode's XCTest framework.
-public enum TestContext: Equatable {
+public enum TestContext: Equatable, Sendable {
   /// The Swift Testing framework.
   case swiftTesting(Testing?)
 
@@ -37,7 +37,7 @@ public enum TestContext: Equatable {
     return true
   }
 
-  public struct Testing: Equatable {
+  public struct Testing: Equatable, Sendable {
     public let test: Test
 
     public struct Test: Equatable, Hashable, Identifiable, Sendable {
@@ -48,7 +48,7 @@ public enum TestContext: Equatable {
         public let isParameterized: Bool
       }
       public struct ID: Equatable, Hashable, @unchecked Sendable {
-        fileprivate let rawValue: AnyHashable
+        public let rawValue: AnyHashable
       }
     }
   }


### PR DESCRIPTION
This allows Issue Reporting's provided ID to be compared to the underlying Test.ID value from Swift Testing.