### PR TITLE
Update CI to use the Xcode 16 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         xcode:
           - 15.2
           - 15.4
-          - 16_beta_6
+          - '16.0'
     name: macOS
     runs-on: macos-14
     steps:
@@ -50,7 +50,7 @@ jobs:
           - Release
         xcode:
           - 15.4
-          - 16_beta_6
+          - '16.0'
     name: Examples
     runs-on: macos-14
     steps:


### PR DESCRIPTION
16 beta 6 has been removed from the image.