### PR TITLE
Address build issues occurring when building with Library Evolution support, Xcode 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_15.4.app
+      run: sudo xcode-select -s /Applications/Xcode_16.0.app
     - name: Run tests
       run: make build-for-library-evolution
 

--- a/Sources/IssueReporting/ReportIssue.swift
+++ b/Sources/IssueReporting/ReportIssue.swift
@@ -34,22 +34,7 @@ public func reportIssue(
   line: UInt = #line,
   column: UInt = #column
 ) {
-  switch TestContext.current {
-  case .swiftTesting:
-    _recordIssue(
-      message: message(),
-      fileID: "\(IssueContext.current?.fileID ?? fileID)",
-      filePath: "\(IssueContext.current?.filePath ?? filePath)",
-      line: Int(IssueContext.current?.line ?? line),
-      column: Int(IssueContext.current?.column ?? column)
-    )
-  case .xcTest:
-    _XCTFail(
-      message().withAppHostWarningIfNeeded() ?? "",
-      file: IssueContext.current?.filePath ?? filePath,
-      line: IssueContext.current?.line ?? line
-    )
-  case nil:
+  guard let context = TestContext.current else {
     guard !isTesting else { return }
     if let observer = FailureObserver.current {
       observer.withLock { $0 += 1 }
@@ -73,6 +58,25 @@ public func reportIssue(
         )
       }
     }
+    return
+  }
+
+  switch context {
+  case .swiftTesting:
+    _recordIssue(
+      message: message(),
+      fileID: "\(IssueContext.current?.fileID ?? fileID)",
+      filePath: "\(IssueContext.current?.filePath ?? filePath)",
+      line: Int(IssueContext.current?.line ?? line),
+      column: Int(IssueContext.current?.column ?? column)
+    )
+  case .xcTest:
+    _XCTFail(
+      message().withAppHostWarningIfNeeded() ?? "",
+      file: IssueContext.current?.filePath ?? filePath,
+      line: IssueContext.current?.line ?? line
+    )
+  @unknown default: break
   }
 }
 
@@ -97,23 +101,7 @@ public func reportIssue(
   line: UInt = #line,
   column: UInt = #column
 ) {
-  switch TestContext.current {
-  case .swiftTesting:
-    _recordError(
-      error: error,
-      message: message(),
-      fileID: "\(IssueContext.current?.fileID ?? fileID)",
-      filePath: "\(IssueContext.current?.filePath ?? filePath)",
-      line: Int(IssueContext.current?.line ?? line),
-      column: Int(IssueContext.current?.column ?? column)
-    )
-  case .xcTest:
-    _XCTFail(
-      "Caught error: \(error)\(message().map { ": \($0)" } ?? "")".withAppHostWarningIfNeeded(),
-      file: IssueContext.current?.filePath ?? filePath,
-      line: IssueContext.current?.line ?? line
-    )
-  case nil:
+  guard let context = TestContext.current else {
     guard !isTesting else { return }
     if let observer = FailureObserver.current {
       observer.withLock { $0 += 1 }
@@ -139,5 +127,25 @@ public func reportIssue(
         )
       }
     }
+    return
+  }
+
+  switch context {
+  case .swiftTesting:
+    _recordError(
+      error: error,
+      message: message(),
+      fileID: "\(IssueContext.current?.fileID ?? fileID)",
+      filePath: "\(IssueContext.current?.filePath ?? filePath)",
+      line: Int(IssueContext.current?.line ?? line),
+      column: Int(IssueContext.current?.column ?? column)
+    )
+  case .xcTest:
+    _XCTFail(
+      "Caught error: \(error)\(message().map { ": \($0)" } ?? "")".withAppHostWarningIfNeeded(),
+      file: IssueContext.current?.filePath ?? filePath,
+      line: IssueContext.current?.line ?? line
+    )
+  @unknown default: break
   }
 }


### PR DESCRIPTION
Address build issues seen building for library evolution mode, Xcode 16 - i.e. via `make build-for-library-evolution`.

![image](https://github.com/user-attachments/assets/77a4c17a-5ba2-499e-b1cb-5834d72ae3b4)