### PR TITLE
Print runtime warning in previews.

### DIFF
--- a/Examples/Examples/ExamplesApp.swift
+++ b/Examples/Examples/ExamplesApp.swift
@@ -26,3 +26,8 @@ class ItemsModel {
     return lastItem
   }
 }
+
+#Preview {
+  let model = ItemsModel()
+  Text(model.lastItem?.description ?? "No last item")
+}

--- a/Examples/Examples/ExamplesApp.swift
+++ b/Examples/Examples/ExamplesApp.swift
@@ -27,7 +27,9 @@ class ItemsModel {
   }
 }
 
-#Preview {
-  let model = ItemsModel()
-  Text(model.lastItem?.description ?? "No last item")
+struct Previews: PreviewProvider {
+  static var previews: some View {
+    let model = ItemsModel()
+    Text(model.lastItem?.description ?? "No last item")
+  }
 }

--- a/Sources/IssueReporting/IssueReporters/RuntimeWarningReporter.swift
+++ b/Sources/IssueReporting/IssueReporters/RuntimeWarningReporter.swift
@@ -66,6 +66,11 @@ public struct _RuntimeWarningReporter: IssueReporter {
     column: UInt
   ) {
     #if canImport(os)
+    guard ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1"
+    else {
+      print("🟣 \(fileID):\(line): \(message() ?? "")")
+      return
+    }
       let moduleName = String(
         Substring("\(fileID)".utf8.prefix(while: { $0 != UTF8.CodeUnit(ascii: "/") }))
       )


### PR DESCRIPTION
This came up in Slack today, but currently runtime warnings go into the void in previews because previews don't see `os_log`. So, if we detect we are in previews we can decide to log to the console instead:

<img width="1106" alt="Screenshot 2024-09-26 at 9 39 53 AM" src="https://github.com/user-attachments/assets/abfdd988-18bf-4a70-8be4-358379e271c1">
