### PR TITLE
Add ability to override the TestContext during an operation

### DIFF
--- a/Sources/IssueReporting/TestContext.swift
+++ b/Sources/IssueReporting/TestContext.swift
@@ -7,6 +7,12 @@ public enum TestContext: Equatable, Sendable {
   /// The XCTest framework.
   case xcTest
 
+  /// Support overriding the `swift-testing` context.
+  ///
+  /// This can be used to during `Trait.prepare` to ensure code called during `prepare` sees the
+  /// same test ID as code run during the body of the test.
+  @TaskLocal private static var override: Testing?
+
   /// The context associated with current test.
   ///
   /// How the test context is detected depends on the framework:
@@ -23,6 +29,11 @@ public enum TestContext: Equatable, Sendable {
   /// If executed outside of a test process, this will return `nil`.
   public static var current: Self? {
     guard isTesting else { return nil }
+
+    if let override {
+      return .swiftTesting(override)
+    }
+
     if let currentTestID = _currentTestID() {
       return .swiftTesting(Testing(id: currentTestID))
     } else {
@@ -35,6 +46,16 @@ public enum TestContext: Equatable, Sendable {
     guard case .swiftTesting = self
     else { return false }
     return true
+  }
+
+  /// Updates the test context with the test ID for the duration of a synchronous operation.
+  ///
+  /// - Parameters:
+  ///   - testID: The test ID to override for the duration of `operation`.
+  ///   - operation: An operation to perform with the overridden test ID.
+  /// - Returns: The result returned from `operation`.
+  public static func withTestID<ID, R>(_ testID: ID, operation: () throws -> R) rethrows -> R where ID: Hashable, ID: Sendable {
+    try $override.withValue(Testing(id: testID), operation: operation)
   }
 
   public struct Testing: Equatable, Sendable {


### PR DESCRIPTION
Add the ability to override the `TestContext` for the duration of an operation.

This will be used to resolve the issue from [this PR](https://github.com/pointfreeco/swift-dependencies/pull/293) without having to add hacky code to `DependencyValues`.

It could also be used for any other implementations of `Testing.Trait`