### PR TITLE
Add @_transparency attribute to reportIssue(_:_:) default implementation

### DIFF
--- a/Sources/IssueReporting/IssueReporter.swift
+++ b/Sources/IssueReporting/IssueReporter.swift
@@ -77,6 +77,7 @@ public protocol IssueReporter: Sendable {
 }
 
 extension IssueReporter {
+  @_transparent
   public func reportIssue(
     _ error: any Error,
     _ message: @autoclosure () -> String?,


### PR DESCRIPTION
When integrating the latest versions into our app I noticed https://github.com/pointfreeco/swift-issue-reporting/issues/139. The fix here is the copy the default protocol extension implementation of `reportIssue(_:_:)` (the one that takes an error as a parameter) inside `_RuntimeWarningReporter` and add the `@_transparent` attribute.

Verified in my work project that this works as expected! Photos are below (ignore the `attributes` parameter, that comes from our wrapper code around this library but doesn't affect the result)

| Before | After |
|--------|--------|
| <img width="1129" alt="image" src="https://github.com/user-attachments/assets/7e493c85-b4c3-4746-aa92-50cd64286951"> | <img width="1365" alt="image" src="https://github.com/user-attachments/assets/59568d59-d525-4e73-930f-b32999996a91"> | 