### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  macos:
+  macos-15:
     strategy:
       matrix:
         config:
@@ -30,7 +30,7 @@ jobs:
     - name: Run tests
       run: make test-${{ matrix.config }}
 
-  macos:
+  macos-14:
     strategy:
       matrix:
         config:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,26 @@ jobs:
           - debug
           - release
         xcode:
+          - '16.0'
+    name: macOS 15
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+    - name: Run tests
+      run: make test-${{ matrix.config }}
+
+  macos:
+    strategy:
+      matrix:
+        config:
+          - debug
+          - release
+        xcode:
           - 15.2
           - 15.4
-          - '16.0'
-    name: macOS
+    name: macOS 14
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +50,7 @@ jobs:
 
   library-evolution:
     name: Library evolution
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode
@@ -49,10 +65,9 @@ jobs:
           - Debug
           - Release
         xcode:
-          - 15.4
           - '16.0'
     name: Examples
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test-examples:
 		-configuration $(CONFIG) \
 		-workspace IssueReporting.xcworkspace \
 		-scheme Examples \
-		-destination platform="iOS Simulator,name=iPhone 15"
+		-destination platform="iOS Simulator,name=iPhone 16"
 
 test-wasm:
 	echo wasm-DEVELOPMENT-SNAPSHOT-2024-07-16-a > .swift-version


### PR DESCRIPTION
GitHub quietly dropped Xcode 16 support for macOS 14, and does not support Xcode <16 on macOS 14, so we have to update our workflow to account for these mismatches.