### PR TITLE
feat: Add the ability to disable test failures on report issue

### DIFF
--- a/Sources/IssueReporting/ReportIssue.swift
+++ b/Sources/IssueReporting/ReportIssue.swift
@@ -60,23 +60,25 @@ public func reportIssue(
     }
     return
   }
-
-  switch context {
-  case .swiftTesting:
-    _recordIssue(
-      message: message(),
-      fileID: "\(IssueContext.current?.fileID ?? fileID)",
-      filePath: "\(IssueContext.current?.filePath ?? filePath)",
-      line: Int(IssueContext.current?.line ?? line),
-      column: Int(IssueContext.current?.column ?? column)
-    )
-  case .xcTest:
-    _XCTFail(
-      message().withAppHostWarningIfNeeded() ?? "",
-      file: IssueContext.current?.filePath ?? filePath,
-      line: IssueContext.current?.line ?? line
-    )
-  @unknown default: break
+  
+  if TestContext.emitsFailureOnReportIssue {
+    switch context {
+    case .swiftTesting:
+      _recordIssue(
+        message: message(),
+        fileID: "\(IssueContext.current?.fileID ?? fileID)",
+        filePath: "\(IssueContext.current?.filePath ?? filePath)",
+        line: Int(IssueContext.current?.line ?? line),
+        column: Int(IssueContext.current?.column ?? column)
+      )
+    case .xcTest:
+      _XCTFail(
+        message().withAppHostWarningIfNeeded() ?? "",
+        file: IssueContext.current?.filePath ?? filePath,
+        line: IssueContext.current?.line ?? line
+      )
+    @unknown default: break
+    }
   }
 }
 
@@ -130,22 +132,24 @@ public func reportIssue(
     return
   }
 
-  switch context {
-  case .swiftTesting:
-    _recordError(
-      error: error,
-      message: message(),
-      fileID: "\(IssueContext.current?.fileID ?? fileID)",
-      filePath: "\(IssueContext.current?.filePath ?? filePath)",
-      line: Int(IssueContext.current?.line ?? line),
-      column: Int(IssueContext.current?.column ?? column)
-    )
-  case .xcTest:
-    _XCTFail(
-      "Caught error: \(error)\(message().map { ": \($0)" } ?? "")".withAppHostWarningIfNeeded(),
-      file: IssueContext.current?.filePath ?? filePath,
-      line: IssueContext.current?.line ?? line
-    )
-  @unknown default: break
+  if TestContext.emitsFailureOnReportIssue {
+    switch context {
+    case .swiftTesting:
+      _recordError(
+        error: error,
+        message: message(),
+        fileID: "\(IssueContext.current?.fileID ?? fileID)",
+        filePath: "\(IssueContext.current?.filePath ?? filePath)",
+        line: Int(IssueContext.current?.line ?? line),
+        column: Int(IssueContext.current?.column ?? column)
+      )
+    case .xcTest:
+      _XCTFail(
+        "Caught error: \(error)\(message().map { ": \($0)" } ?? "")".withAppHostWarningIfNeeded(),
+        file: IssueContext.current?.filePath ?? filePath,
+        line: IssueContext.current?.line ?? line
+      )
+    @unknown default: break
+    }
   }
 }

--- a/Sources/IssueReporting/TestContext.swift
+++ b/Sources/IssueReporting/TestContext.swift
@@ -113,7 +113,7 @@ public func withEmitsFailureOnReportIssue<R>(
   }
 #else
   @_unsafeInheritExecutor
-  public func withIssueReporters<R>(
+  public func withEmitsFailureOnReportIssue<R>(
     _ value: Bool,
     operation: () async throws -> R
   ) async rethrows -> R {

--- a/Tests/IssueReportingTests/SwiftTestingTests.swift
+++ b/Tests/IssueReportingTests/SwiftTestingTests.swift
@@ -45,6 +45,12 @@
         issue.description == "Caught error: Failure(): Something went wrong"
       }
     }
+    
+    @Test func reportIssue_EmitFailureDisabled() {
+      withEmitsFailureOnReportIssue(false) {
+        reportIssue()
+      }
+    }
 
     @Test func withExpectedIssue_reportIssue() {
       withExpectedIssue {

--- a/Tests/IssueReportingTests/XCTestTests.swift
+++ b/Tests/IssueReportingTests/XCTestTests.swift
@@ -33,6 +33,12 @@ final class XCTestTests: XCTestCase {
         $0.compactDescription == "failed - Something went wrong"
       }
     }
+  
+    func testReportIssue_EmitFailureDisabled() {
+      withEmitsFailureOnReportIssue(false) {
+        reportIssue()
+      }
+    }
 
     func testWithExpectedIssue() {
       withExpectedIssue {


### PR DESCRIPTION
Adds the ability to disable the current default behaviour of triggering a test failure whenever reportIssue is called in a testing context with a new flag `TestContext.emitsFailureOnReportIssue`. This value can be overridden for a single operation using the `withEmitsFailureOnReportIssue(_)` helper function.

Resolves #145.