### PR TITLE
Add isolation to `withExpectedIssue` and `withIssueContext`

### DIFF
--- a/Sources/IssueReporting/Documentation.docc/Extensions/withExpectedIssue.md
+++ b/Sources/IssueReporting/Documentation.docc/Extensions/withExpectedIssue.md
@@ -1,7 +1,7 @@
-# ``IssueReporting/withExpectedIssue(_:isIntermittent:fileID:filePath:line:column:_:)-9pinm``
+# ``IssueReporting/withExpectedIssue(_:isIntermittent:fileID:filePath:line:column:_:)``
 
 ## Topics
 
 ### Overloads
 
-- ``IssueReporting/withExpectedIssue(_:isIntermittent:fileID:filePath:line:column:_:)-7noz2``
+- ``IssueReporting/withExpectedIssue(_:isIntermittent:isolation:fileID:filePath:line:column:_:)``

--- a/Sources/IssueReporting/Documentation.docc/Extensions/withIssueContext.md
+++ b/Sources/IssueReporting/Documentation.docc/Extensions/withIssueContext.md
@@ -1,7 +1,7 @@
-# ``IssueReporting/withIssueContext(fileID:filePath:line:column:operation:)-97lux``
+# ``IssueReporting/withIssueContext(fileID:filePath:line:column:operation:)``
 
 ## Topics
 
 ### Overloads
 
-- ``withIssueContext(fileID:filePath:line:column:operation:)-6o3dr``
+- ``withIssueContext(fileID:filePath:line:column:isolation:operation:)``

--- a/Sources/IssueReporting/Internal/SwiftTesting.swift
+++ b/Sources/IssueReporting/Internal/SwiftTesting.swift
@@ -166,73 +166,150 @@ func _withKnownIssue(
   withKnownIssue(message, isIntermittent, fileID, filePath, line, column, body)
 }
 
-@usableFromInline
-func _withKnownIssue(
-  _ message: String? = nil,
-  isIntermittent: Bool = false,
-  fileID: String = #fileID,
-  filePath: String = #filePath,
-  line: Int = #line,
-  column: Int = #column,
-  _ body: () async throws -> Void
-) async {
-  guard let function = function(for: "$s25IssueReportingTestSupport010_withKnownA5AsyncypyF")
-  else {
-    #if DEBUG
-      guard
-        let withKnownIssue = unsafeBitCast(
-          symbol: """
-            $s7Testing14withKnownIssue_14isIntermittent14sourceLocation_yAA7CommentVSg_SbAA06Source\
-            H0VyyYaKXEtYaFTu
-            """,
-          in: "Testing",
-          to: (@convention(thin) (
-            Any?,
-            Bool,
-            SourceLocation,
-            () async throws -> Void
-          ) async -> Void)
-          .self
+#if compiler(>=6.0.2)
+  @usableFromInline
+  func _withKnownIssue(
+    _ message: String?,
+    isIntermittent: Bool,
+    isolation: isolated (any Actor)?,
+    fileID: String,
+    filePath: String,
+    line: Int,
+    column: Int,
+    _ body: () async throws -> Void
+  ) async {
+    guard
+      let function = function(for: "$s25IssueReportingTestSupport010_withKnownA13AsyncIsolatedypyF")
+    else {
+      #if DEBUG
+        guard
+          let withKnownIssue = unsafeBitCast(
+            symbol: """
+              $s7Testing14withKnownIssue_14isIntermittent9isolation14sourceLocation_yAA7CommentVSg_\
+              SbScA_pSgYiAA06SourceI0VyyYaKXEtYaF
+              """,
+            in: "Testing",
+            to: (@convention(thin) (
+              Any?,
+              Bool,
+              isolated (any Actor)?,
+              SourceLocation,
+              () async throws -> Void
+            ) async -> Void)
+            .self
+          )
+        else { return }
+
+        var comment: Any?
+        if let message {
+          var c = UnsafeMutablePointer<Comment>.allocate(capacity: 1).pointee
+          c.rawValue = message
+          comment = c
+        }
+        await withKnownIssue(
+          comment,
+          isIntermittent,
+          isolation,
+          SourceLocation(fileID: fileID, _filePath: filePath, line: line, column: column),
+          body
         )
-      else { return }
+      #else
+        printError(
+          """
+          \(fileID):\(line): A known issue was recorded without linking the Testing framework.
 
-      var comment: Any?
-      if let message {
-        var c = UnsafeMutablePointer<Comment>.allocate(capacity: 1).pointee
-        c.rawValue = message
-        comment = c
-      }
-      await withKnownIssue(
-        comment,
-        isIntermittent,
-        SourceLocation(fileID: fileID, _filePath: filePath, line: line, column: column),
-        body
-      )
-    #else
-      printError(
-        """
-        \(fileID):\(line): A known issue was recorded without linking the Testing framework.
+          To fix this, add "IssueReportingTestSupport" as a dependency to your test target.
+          """
+        )
+      #endif
+      return
+    }
 
-        To fix this, add "IssueReportingTestSupport" as a dependency to your test target.
-        """
-      )
-    #endif
-    return
+    let withKnownIssue =
+      function
+      as! @Sendable (
+        String?,
+        Bool,
+        isolated (any Actor)?,
+        String,
+        String,
+        Int,
+        Int,
+        () async throws -> Void
+      ) async -> Void
+    await withKnownIssue(message, isIntermittent, isolation, fileID, filePath, line, column, body)
+  }
+#else
+  @usableFromInline
+  func _withKnownIssue(
+    _ message: String?,
+    isIntermittent: Bool,
+    fileID: String,
+    filePath: String,
+    line: Int,
+    column: Int,
+    _ body: () async throws -> Void
+  ) async {
+    guard let function = function(for: "$s25IssueReportingTestSupport010_withKnownA5AsyncypyF")
+    else {
+      #if DEBUG
+        guard
+          let withKnownIssue = unsafeBitCast(
+            symbol: """
+              $s7Testing14withKnownIssue_14isIntermittent14sourceLocation_yAA7CommentVSg_SbAA06Sour\
+              ceH0VyyYaKXEtYaFTu
+              """,
+            in: "Testing",
+            to: (@convention(thin) (
+              Any?,
+              Bool,
+              SourceLocation,
+              () async throws -> Void
+            ) async -> Void)
+            .self
+          )
+        else { return }
+
+        var comment: Any?
+        if let message {
+          var c = UnsafeMutablePointer<Comment>.allocate(capacity: 1).pointee
+          c.rawValue = message
+          comment = c
+        }
+        await withKnownIssue(
+          comment,
+          isIntermittent,
+          SourceLocation(fileID: fileID, _filePath: filePath, line: line, column: column),
+          body
+        )
+      #else
+        printError(
+          """
+          \(fileID):\(line): A known issue was recorded without linking the Testing framework.
+
+          To fix this, add "IssueReportingTestSupport" as a dependency to your test target.
+          """
+        )
+      #endif
+      return
+    }
+
+    let withKnownIssue =
+      function
+      as! @Sendable (
+        String?,
+        Bool,
+        String,
+        String,
+        Int,
+        Int,
+        () async throws -> Void
+      ) async -> Void
+    await withKnownIssue(message, isIntermittent, fileID, filePath, line, column, body)
   }
 
-  let withKnownIssue =
-    function
-    as! @Sendable (
-      String?,
-      Bool,
-      String,
-      String,
-      Int,
-      Int,
-      () async throws -> Void
-    ) async -> Void
-  await withKnownIssue(message, isIntermittent, fileID, filePath, line, column, body)
-}
+#endif
+
 @usableFromInline
 func _currentTestID() -> AnyHashable? {
   guard let function = function(for: "$s25IssueReportingTestSupport08_currentC2IDypyF")

--- a/Sources/IssueReporting/WithIssueContext.swift
+++ b/Sources/IssueReporting/WithIssueContext.swift
@@ -25,28 +25,45 @@ public func withIssueContext<R>(
   )
 }
 
-/// Sets the context for issues reported for the duration of the asynchronous operation.
-///
-/// An asynchronous version of ``withIssueContext(fileID:filePath:line:column:operation:)-97lux``.
-///
-/// - Parameters:
-///   - fileID: The source `#fileID` to associate with issues reported during the operation.
-///   - filePath: The source `#filePath` to associate with issues reported during the operation.
-///   - line: The source `#line` to associate with issues reported during the operation.
-///   - column: The source `#column` to associate with issues reported during the operation.
-///   - operation: An asynchronous operation.
-public func withIssueContext<R>(
-  fileID: StaticString,
-  filePath: StaticString,
-  line: UInt,
-  column: UInt,
-  operation: () async throws -> R
-) async rethrows -> R {
-  try await IssueContext.$current.withValue(
-    IssueContext(fileID: fileID, filePath: filePath, line: line, column: column),
-    operation: operation
-  )
-}
+#if compiler(>=6)
+  /// Sets the context for issues reported for the duration of the asynchronous operation.
+  ///
+  /// An asynchronous version of ``withIssueContext(fileID:filePath:line:column:operation:)-97lux``.
+  ///
+  /// - Parameters:
+  ///   - fileID: The source `#fileID` to associate with issues reported during the operation.
+  ///   - filePath: The source `#filePath` to associate with issues reported during the operation.
+  ///   - line: The source `#line` to associate with issues reported during the operation.
+  ///   - column: The source `#column` to associate with issues reported during the operation.
+  ///   - operation: An asynchronous operation.
+  public func withIssueContext<R>(
+    fileID: StaticString,
+    filePath: StaticString,
+    line: UInt,
+    column: UInt,
+    isolation: isolated (any Actor)? = #isolation,
+    operation: () async throws -> R
+  ) async rethrows -> R {
+    try await IssueContext.$current.withValue(
+      IssueContext(fileID: fileID, filePath: filePath, line: line, column: column),
+      operation: operation,
+      isolation: isolation
+    )
+  }
+#else
+  public func withIssueContext<R>(
+    fileID: StaticString,
+    filePath: StaticString,
+    line: UInt,
+    column: UInt,
+    operation: () async throws -> R
+  ) async rethrows -> R {
+    try await IssueContext.$current.withValue(
+      IssueContext(fileID: fileID, filePath: filePath, line: line, column: column),
+      operation: operation
+    )
+  }
+#endif
 
 @usableFromInline
 struct IssueContext: Sendable {

--- a/Sources/IssueReportingTestSupport/SwiftTesting.swift
+++ b/Sources/IssueReportingTestSupport/SwiftTesting.swift
@@ -74,7 +74,9 @@ private func __withKnownIssue(
   #endif
 }
 
-public func _withKnownIssueAsync() -> Any { __withKnownIssueAsync }
+public func _withKnownIssueAsync() -> Any {
+  __withKnownIssueAsync(_:isIntermittent:fileID:filePath:line:column:_:)
+}
 @Sendable
 private func __withKnownIssueAsync(
   _ message: String?,
@@ -99,6 +101,38 @@ private func __withKnownIssueAsync(
     )
   #endif
 }
+
+#if compiler(>=6.0.2)
+  public func _withKnownIssueAsyncIsolated() -> Any {
+    __withKnownIssueAsync(_:isIntermittent:isolation:fileID:filePath:line:column:_:)
+  }
+  @Sendable
+  private func __withKnownIssueAsync(
+    _ message: String?,
+    isIntermittent: Bool,
+    isolation: isolated (any Actor)?,
+    fileID: String,
+    filePath: String,
+    line: Int,
+    column: Int,
+    _ body: () async throws -> Void
+  ) async {
+    #if canImport(Testing)
+      await withKnownIssue(
+        message.map(Comment.init(rawValue:)),
+        isIntermittent: isIntermittent,
+        isolation: isolation,
+        sourceLocation: SourceLocation(
+          fileID: fileID,
+          filePath: filePath,
+          line: line,
+          column: column
+        ),
+        body
+      )
+    #endif
+  }
+#endif
 
 public func _currentTestID() -> Any { __currentTestID }
 @Sendable


### PR DESCRIPTION
Should let these helpers be used more places.