### PR TITLE
Fix Swift 5.10 toolchain issue on Linux builds

### DIFF
--- a/Sources/IssueReporting/ErrorReporting.swift
+++ b/Sources/IssueReporting/ErrorReporting.swift
@@ -1,3 +1,7 @@
+// swift-format-ignore
+// Note: Whitespace changes are used to workaround compiler bug
+// https://github.com/swiftlang/swift/issues/79285
+
 /// Evaluates a throwing closure and automatically catches and reports any error thrown.
 ///
 /// - Parameters:
@@ -74,8 +78,9 @@ public func withErrorReporting<R>(
     line: UInt = #line,
     column: UInt = #column,
     isolation: isolated (any Actor)? = #isolation,
-    catching body: () async throws -> sending R
-  ) async -> R? {
+    // DO NOT FIX THE WHITESPACE IN THE NEXT LINE UNTIL 5.10 IS UNSUPPORTED
+    // https://github.com/swiftlang/swift/issues/79285
+    catching body: () async throws -> sending R) async -> R? {
     if let reporters {
       return await withIssueReporters(reporters) {
         do {

--- a/Sources/IssueReporting/ErrorReporting.swift
+++ b/Sources/IssueReporting/ErrorReporting.swift
@@ -1,4 +1,4 @@
-// swift-format-ignore
+// swift-format-ignore-file
 // Note: Whitespace changes are used to workaround compiler bug
 // https://github.com/swiftlang/swift/issues/79285
 


### PR DESCRIPTION
Swift 5.10 has a strange bug that causes compilation to fail on Linux when `if compiler(>=6.0)` blocks are used:
* https://github.com/swiftlang/swift/issues/79285

**swift-issue-reporting** is impacted by this as reported in:
* #150

There is an existing workaround used in AHC:
*  https://github.com/swift-server/async-http-client/pull/810

This PR fixes the issue by using the workaround that involves changing white spaces around the impacted syntax.