### PR TITLE
Fix empty message crash.

### DIFF
--- a/Sources/IssueReportingTestSupport/SwiftTesting.swift
+++ b/Sources/IssueReportingTestSupport/SwiftTesting.swift
@@ -14,6 +14,7 @@ private func __recordIssue(
   column: Int
 ) {
   #if canImport(Testing)
+    let message = message == "" ? nil : message
     Issue.record(
       message.map(Comment.init(rawValue:)),
       sourceLocation: SourceLocation(

--- a/Tests/IssueReportingTests/SwiftTestingTests.swift
+++ b/Tests/IssueReportingTests/SwiftTestingTests.swift
@@ -133,7 +133,7 @@
     @Test
     func emptyMessage() {
       withKnownIssue {
-        reportIssue("hey")
+        reportIssue("")
       }
     }
 
@@ -141,14 +141,14 @@
     func emptyMessage_async() async {
       await withKnownIssue {
         await Task.yield()
-        reportIssue("hey")
+        reportIssue("")
       }
     }
 
     @Test
     func emptyMessage_throws() throws {
       withKnownIssue {
-        reportIssue("hey")
+        reportIssue("")
       }
     }
 

--- a/Tests/IssueReportingTests/SwiftTestingTests.swift
+++ b/Tests/IssueReportingTests/SwiftTestingTests.swift
@@ -133,27 +133,29 @@
     @Test
     func emptyMessage() {
       withKnownIssue {
-        reportIssue("")
+        reportIssue("hey")
       }
     }
 
     @Test
     func emptyMessage_async() async {
-      withKnownIssue {
-        reportIssue("")
+      await withKnownIssue {
+        await Task.yield()
+        reportIssue("hey")
       }
     }
 
     @Test
     func emptyMessage_throws() throws {
       withKnownIssue {
-        reportIssue("")
+        reportIssue("hey")
       }
     }
 
     @Test
     func emptyMessage_asyncThrows() async throws {
-      withKnownIssue {
+      await withKnownIssue {
+        await Task.yield()
         reportIssue("")
       }
     }

--- a/Tests/IssueReportingTests/SwiftTestingTests.swift
+++ b/Tests/IssueReportingTests/SwiftTestingTests.swift
@@ -129,6 +129,34 @@
           && issue.description == "Issue recorded: Something went wrong"
       }
     }
+
+    @Test
+    func emptyMessage() {
+      withKnownIssue {
+        reportIssue("")
+      }
+    }
+
+    @Test
+    func emptyMessage_async() async {
+      withKnownIssue {
+        reportIssue("")
+      }
+    }
+
+    @Test
+    func emptyMessage_throws() throws {
+      withKnownIssue {
+        reportIssue("")
+      }
+    }
+
+    @Test
+    func emptyMessage_asyncThrows() async throws {
+      withKnownIssue {
+        reportIssue("")
+      }
+    }
   }
 
   private struct Failure: Error {}


### PR DESCRIPTION
It appears that Swift Testing will [crash](https://github.com/swiftlang/swift-testing/issues/1107) when recording an issue with an empty comment:

```swift
Issue.record("")  // 🛑
```

I think we should work around this problem for `reportIssue` since they are typically used in app code and so has a great chance of a custom message being crafted that may end up as an empty string.