### PR TITLE
feat: add `reportIfNil` to report unexpected nil values

### DIFF
--- a/Sources/IssueReporting/ReportIfNil.swift
+++ b/Sources/IssueReporting/ReportIfNil.swift
@@ -1,0 +1,42 @@
+/// Evaluates a value and reports an issue if it is nil.
+///
+/// - Parameters:
+///   - value: The value to check for nil.
+///   - message: A message describing the expectation.
+///   - reporters: Issue reporters to notify if the value is nil.
+///   - fileID: The source `#fileID` associated with the issue reporting.
+///   - filePath: The source `#filePath` associated with the issue reporting.
+///   - line: The source `#line` associated with the issue reporting.
+///   - column: The source `#column` associated with the issue reporting.
+/// - Returns: The optional value, unchanged.
+@_transparent
+public func reportIfNil<T>(
+    _ value: T?,
+    message: @autoclosure () -> String = "Unexpected nil value",
+    to reporters: [any IssueReporter]? = nil,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
+    line: UInt = #line,
+    column: UInt = #column
+) -> T? {
+  
+    guard let value else {
+      withErrorReporting(
+        message(),
+        to: reporters,
+        fileID: fileID,
+        filePath: filePath,
+        line: line,
+        column: column
+      ) {
+        throw NilValueError()
+      }
+      return nil
+    }
+  
+    return value
+}
+
+public struct NilValueError: Error {
+  public init() {}
+}

--- a/Tests/IssueReportingTests/ReportIfNilTests.swift
+++ b/Tests/IssueReportingTests/ReportIfNilTests.swift
@@ -1,0 +1,35 @@
+#if canImport(Testing) && !os(Windows)
+import Testing
+import IssueReporting
+
+@Suite
+struct ReportIfNilTests {
+
+  @Test
+  func reportsIssueForNilValueWithDefaultMessage() {
+    withKnownIssue {
+      _ = reportIfNil(Optional<String>.none)
+    } matching: { issue in
+      issue.error is NilValueError &&
+      issue.description == "Caught error: NilValueError(): Unexpected nil value"
+    }
+  }
+
+  @Test
+  func reportsIssueForNilValueWithCustomMessage() {
+    withKnownIssue {
+      _ = reportIfNil(Optional<String>.none, message: "Custom nil message")
+    } matching: { issue in
+      issue.error is NilValueError &&
+      issue.description == "Caught error: NilValueError(): Custom nil message"
+    }
+  }
+
+  @Test
+  func doesNotReportIssueForNonNilValue() {
+    let value: String? = "non-nil"
+    #expect(reportIfNil(value) == "non-nil")
+  }
+}
+
+#endif


### PR DESCRIPTION
## Add `reportIfNil`: Report unexpected `nil` values as issues

This PR introduces a new utility, `reportIfNil`, to the `swift-issue-reporting` library. It evaluates an optional value and reports an issue if the value is `nil`, using the existing `IssueReporter` infrastructure.

---

### Motivation

While `withErrorReporting` handles thrown errors, there is currently no equivalent for reporting unexpected `nil` values — a common source of bugs in Swift.

---

### Tests Included

Tests are split into focused cases for better clarity and maintainability:

- ✅ Reports issue for `nil` value with default message
- ✅ Reports issue for `nil` value with custom message
- ✅ Does **not** report issue when value is non-`nil`

---

### Related

Complements existing `withErrorReporting` functionality by offering a similar utility for handling optional values that shouldn't be `nil`.