### PR TITLE
Xcode 26 (Swift 6.2) fixes

### DIFF
--- a/Tests/IssueReportingTests/Support.swift
+++ b/Tests/IssueReportingTests/Support.swift
@@ -1,0 +1,5 @@
+#if compiler(>=6.2)
+  let issueDescriptionSuffix = " (error)"
+#else
+  let issueDescriptionSuffix = ""
+#endif

--- a/Tests/IssueReportingTests/SwiftTestingTests.swift
+++ b/Tests/IssueReportingTests/SwiftTestingTests.swift
@@ -17,7 +17,7 @@
       withKnownIssue {
         reportIssue()
       } matching: { issue in
-        issue.description == "Issue recorded"
+        issue.description == "Issue recorded\(issueDescriptionSuffix)"
       }
     }
 
@@ -26,7 +26,7 @@
       withKnownIssue {
         reportIssue(Failure())
       } matching: { issue in
-        issue.description == "Caught error: Failure()"
+        issue.description == "Caught error: Failure()\(issueDescriptionSuffix)"
       }
     }
 
@@ -34,7 +34,7 @@
       withKnownIssue {
         reportIssue("Something went wrong")
       } matching: { issue in
-        issue.description == "Issue recorded: Something went wrong"
+        issue.description == "Issue recorded\(issueDescriptionSuffix): Something went wrong"
       }
     }
 
@@ -42,7 +42,7 @@
       withKnownIssue {
         reportIssue(Failure(), "Something went wrong")
       } matching: { issue in
-        issue.description == "Caught error: Failure(): Something went wrong"
+        issue.description == "Caught error: Failure()\(issueDescriptionSuffix): Something went wrong"
       }
     }
 
@@ -74,7 +74,7 @@
         withExpectedIssue {
         }
       } matching: { issue in
-        issue.description == "Known issue was not recorded"
+        issue.description == "Known issue was not recorded\(issueDescriptionSuffix)"
       }
     }
 
@@ -84,7 +84,7 @@
           await Task.yield()
         }
       } matching: { issue in
-        issue.description == "Known issue was not recorded"
+        issue.description == "Known issue was not recorded\(issueDescriptionSuffix)"
       }
     }
 
@@ -93,7 +93,7 @@
         withExpectedIssue("This didn't fail") {
         }
       } matching: { issue in
-        issue.description == "Known issue was not recorded: This didn't fail"
+        issue.description == "Known issue was not recorded\(issueDescriptionSuffix): This didn't fail"
       }
     }
 
@@ -103,7 +103,7 @@
           await Task.yield()
         }
       } matching: { issue in
-        issue.description == "Known issue was not recorded: This didn't fail"
+        issue.description == "Known issue was not recorded\(issueDescriptionSuffix): This didn't fail"
       }
     }
 
@@ -126,7 +126,7 @@
       } matching: { issue in
         let expectedReportingLine = #line - 4
         return issue.sourceLocation?.line == expectedReportingLine
-          && issue.description == "Issue recorded: Something went wrong"
+          && issue.description == "Issue recorded\(issueDescriptionSuffix): Something went wrong"
       }
     }
 

--- a/Tests/IssueReportingTests/UnimplementedTests.swift
+++ b/Tests/IssueReportingTests/UnimplementedTests.swift
@@ -15,7 +15,7 @@
         model.callback(42)
       } matching: { issue in
         issue.description == """
-          Issue recorded: Unimplemented …
+          Issue recorded\(issueDescriptionSuffix): Unimplemented …
 
             Defined in 'Model' at:
               IssueReportingTests/UnimplementedTests.swift:\(model.line)
@@ -37,7 +37,7 @@
         model.callback()
       } matching: { issue in
         issue.description == """
-          Issue recorded: Unimplemented …
+          Issue recorded\(issueDescriptionSuffix): Unimplemented …
 
             Defined in 'Model' at:
               IssueReportingTests/UnimplementedTests.swift:\(model.line)
@@ -59,7 +59,7 @@
         _ = model.callback()
       } matching: { issue in
         issue.description == """
-          Issue recorded: Unimplemented …
+          Issue recorded\(issueDescriptionSuffix): Unimplemented …
 
             Defined in 'Model' at:
               IssueReportingTests/UnimplementedTests.swift:\(model.line)
@@ -81,7 +81,7 @@
         _ = try model.callback()
       } matching: { issue in
         issue.description == """
-          Issue recorded: Unimplemented …
+          Issue recorded\(issueDescriptionSuffix): Unimplemented …
 
             Defined in 'Model' at:
               IssueReportingTests/UnimplementedTests.swift:\(model.line)
@@ -90,7 +90,7 @@
               ()
           """
           || issue.description == """
-            Caught error: UnimplementedFailure(description: "")
+            Caught error: UnimplementedFailure(description: "")\(issueDescriptionSuffix)
             """
       }
     }
@@ -107,7 +107,7 @@
           _ = try model.callback()
         } matching: { issue in
           issue.description == """
-            Issue recorded: Unimplemented …
+            Issue recorded\(issueDescriptionSuffix): Unimplemented …
 
               Defined in 'Model' at:
                 IssueReportingTests/UnimplementedTests.swift:\(model.line)
@@ -118,7 +118,7 @@
         }
       } matching: { issue in
         issue.description == """
-          Caught error: UnimplementedFailure(description: "")
+          Caught error: UnimplementedFailure(description: "")\(issueDescriptionSuffix)
           """
       }
     }
@@ -136,7 +136,7 @@
           _ = try model.callback()
         } matching: { issue in
           issue.description == """
-            Issue recorded: Unimplemented …
+            Issue recorded\(issueDescriptionSuffix): Unimplemented …
 
               Defined in 'Model' at:
                 IssueReportingTests/UnimplementedTests.swift:\(model.line)
@@ -147,7 +147,7 @@
         }
       } matching: { issue in
         issue.description == """
-          Caught error: UnimplementedFailure(description: "")
+          Caught error: UnimplementedFailure(description: "")\(issueDescriptionSuffix)
           """
       }
     }

--- a/Tests/IssueReportingTests/WithErrorReportingTests.swift
+++ b/Tests/IssueReportingTests/WithErrorReportingTests.swift
@@ -10,7 +10,7 @@
           throw SomeError()
         }
       } matching: { issue in
-        issue.description == "Caught error: SomeError()"
+        issue.description == "Caught error: SomeError()\(issueDescriptionSuffix)"
       }
 
       withKnownIssue {
@@ -18,7 +18,7 @@
           throw SomeError()
         }
       } matching: { issue in
-        issue.description == "Caught error: SomeError(): Failed"
+        issue.description == "Caught error: SomeError()\(issueDescriptionSuffix): Failed"
       }
     }
 
@@ -28,7 +28,7 @@
           throw SomeError()
         }
       } matching: { issue in
-        issue.description == "Caught error: SomeError()"
+        issue.description == "Caught error: SomeError()\(issueDescriptionSuffix)"
       }
 
       await withKnownIssue {
@@ -36,20 +36,22 @@
           throw SomeError()
         }
       } matching: { issue in
-        issue.description == "Caught error: SomeError(): Failed"
+        issue.description == "Caught error: SomeError()\(issueDescriptionSuffix): Failed"
       }
     }
 
-    @MainActor
-    @Test func isolation() async {
-      await withKnownIssue {
-        await withErrorReporting { () async throws in
-          throw SomeError()
+    #if compiler(<6.2)
+      @MainActor
+      @Test func isolation() async {
+        await withKnownIssue {
+          await withErrorReporting { () async throws in
+            throw SomeError()
+          }
+        } matching: { issue in
+          issue.description == "Caught error: SomeError()"
         }
-      } matching: { issue in
-        issue.description == "Caught error: SomeError()"
       }
-    }
+    #endif
   }
 
   private struct SomeError: Error {}


### PR DESCRIPTION
I'm sure this is a moving target, but this fixes crashes that are happening when TestSupport isn't linked.