### PR TITLE
Always invoke `Issue.record` and `XCTFail` in tests

### DIFF
--- a/Sources/IssueReporting/ReportIssue.swift
+++ b/Sources/IssueReporting/ReportIssue.swift
@@ -40,7 +40,7 @@ public func reportIssue(
     IssueContext.current?.line ?? line,
     IssueContext.current?.column ?? column
   )
-  guard let context = TestContext.current else {
+  guard TestContext.current != nil else {
     guard !isTesting else { return }
     if let observer = FailureObserver.current {
       observer.withLock { $0 += 1 }
@@ -66,24 +66,18 @@ public func reportIssue(
     }
     return
   }
-
-  switch context {
-  case .swiftTesting:
-    _recordIssue(
-      message: message(),
-      fileID: "\(fileID)",
-      filePath: "\(filePath)",
-      line: Int(line),
-      column: Int(column)
-    )
-  case .xcTest:
-    _XCTFail(
-      message().withAppHostWarningIfNeeded() ?? "",
-      file: filePath,
-      line: line
-    )
-  @unknown default: break
-  }
+  _recordIssue(
+    message: message(),
+    fileID: "\(fileID)",
+    filePath: "\(filePath)",
+    line: Int(line),
+    column: Int(column)
+  )
+  _XCTFail(
+    message().withAppHostWarningIfNeeded() ?? "",
+    file: filePath,
+    line: line
+  )
 }
 
 /// Report a caught error.


### PR DESCRIPTION
That way, `Issue.record` properly funnels to Swift Testing when called from an unstructured place, like `isolated deinit`s. It also doesn't hurt to invoke `XCTFail` from `Swift Testing`, or vice versa.

Fixes #170.