### PR TITLE
fix: change package access to public for broader build compatibility

### DIFF
--- a/Sources/IssueReportingPackageSupport/_Test.swift
+++ b/Sources/IssueReportingPackageSupport/_Test.swift
@@ -1,13 +1,8 @@
-@usableFromInline
-package struct _Test {
-  @usableFromInline
-  package let id: AnyHashable
+public struct _Test {
+  public let id: AnyHashable
+  public let traits: [any Sendable]
 
-  @usableFromInline
-  package let traits: [any Sendable]
-
-  @usableFromInline
-  package init(id: AnyHashable, traits: [any Sendable]) {
+  public init(id: AnyHashable, traits: [any Sendable]) {
     self.id = id
     self.traits = traits
   }


### PR DESCRIPTION
The `package` access modifier can cause build failures in certain contexts where Swift cannot determine the package identity. This changes `package` to `public` which maintains the same visibility while being more broadly compatible with different build environments and tooling.