### PR TITLE
Fix deprecation placed on wrong reportIssue overload

### DIFF
--- a/Sources/IssueReporting/Internal/Deprecations.swift
+++ b/Sources/IssueReporting/Internal/Deprecations.swift
@@ -2,11 +2,6 @@
 
 extension IssueReporter {
   @_transparent
-  @available(
-    *,
-    deprecated,
-    message: "Implement 'reportIssue(_:severity:fileID:filePath:line:column:)' instead."
-  )
   public func reportIssue(
     _ message: @autoclosure () -> String?,
     severity: IssueSeverity,

--- a/Sources/IssueReporting/IssueReporter.swift
+++ b/Sources/IssueReporting/IssueReporter.swift
@@ -89,6 +89,11 @@ public protocol IssueReporter: Sendable {
   ///   - filePath: The source `#filePath` associated with the issue.
   ///   - line: The source `#line` associated with the issue.
   ///   - column: The source `#column` associated with the issue.
+  @available(
+    *,
+    deprecated,
+    message: "Implement 'reportIssue(_:severity:fileID:filePath:line:column:)' instead."
+  )
   func reportIssue(
     _ message: @autoclosure () -> String?,
     fileID: StaticString,
@@ -100,6 +105,11 @@ public protocol IssueReporter: Sendable {
 
 extension IssueReporter {
   @_transparent
+  @available(
+    *,
+    deprecated,
+    message: "Implement 'reportIssue(_:severity:fileID:filePath:line:column:)' instead."
+  )
   public func reportIssue(
     _ message: @autoclosure () -> String?,
     fileID: StaticString,


### PR DESCRIPTION
The @available(*, deprecated) annotation was mistakenly placed on the new severity-bearing default implementation in Deprecations.swift, making it look like calling reportIssue(_:severity:...) was deprecated.

Move the deprecation to the old no-severity protocol requirement and its default implementation, which are the APIs conformers should migrate away from. 

The severity shim in Deprecations.swift remains as a silent backward-compatibility bridge for old conformers.