### PR TITLE
Remove dead import FoundationNetworking from Deprecations.swift

### DIFF
--- a/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
@@ -1,8 +1,11 @@
 import Foundation
 
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
+// Note: this file does not reference any `FoundationNetworking`-specific
+// types — `URL` is in `Foundation` proper, even on swift-corelibs-Foundation
+// platforms. The previous `#if canImport(FoundationNetworking) / import
+// FoundationNetworking` block was a no-op import that nonetheless caused the
+// linker to add `libFoundationNetworking.so` to `DT_NEEDED` (~16 MB) for
+// Android cross-compile consumers. Removed entirely.
 
 // NB: Deprecated after 1.1.2
 

--- a/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
@@ -1,11 +1,5 @@
 import Foundation
 
-// Note: this file does not reference any `FoundationNetworking`-specific
-// types — `URL` is in `Foundation` proper, even on swift-corelibs-Foundation
-// platforms. The previous `#if canImport(FoundationNetworking) / import
-// FoundationNetworking` block was a no-op import that nonetheless caused the
-// linker to add `libFoundationNetworking.so` to `DT_NEEDED` (~16 MB) for
-// Android cross-compile consumers. Removed entirely.
 
 // NB: Deprecated after 1.1.2
 


### PR DESCRIPTION
The `extension URL: _DefaultInitializable` under `#if canImport(FoundationNetworking)` uses `URL`, which lives in `Foundation` proper — not `FoundationNetworking` — even on swift-corelibs-Foundation platforms (Linux/Android). The `import FoundationNetworking` is therefore a no-op for type resolution. It does, however, cause the linker to add `libFoundationNetworking.so` to `DT_NEEDED` on Android cross-compile builds, ~16 MB of dead weight for consumers that don't otherwise touch URLSession. The surrounding `#if canImport(FoundationNetworking)` gate stays as a "split-Foundation platform" discriminator.