### PR TITLE
Modernize package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - debug
           - release
         xcode:
-          - '26.1'
+          - '26.5'
     name: macOS 26
     runs-on: macos-26
     steps:
@@ -33,11 +33,11 @@ jobs:
 
   library-evolution:
     name: Library evolution
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
     - uses: actions/checkout@v5
     - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app
+      run: sudo xcode-select -s /Applications/Xcode_26.5.app
     - name: Run tests
       run: make build-for-library-evolution
 
@@ -48,7 +48,7 @@ jobs:
           - Debug
           - Release
         xcode:
-          - '26.1'
+          - '26.5'
     name: Examples
     runs-on: macos-26
     steps:
@@ -66,7 +66,7 @@ jobs:
           - release
     name: Linux
     runs-on: ubuntu-latest
-    container: swift:6.0.3
+    container: swift:6.3
     steps:
       - uses: actions/checkout@v5
       - name: Install dependencies
@@ -75,52 +75,3 @@ jobs:
         run: make test-${{ matrix.config }}
       - name: Build for static-stdlib
         run: make CONFIG=${{ matrix.config }} build-for-static-stdlib
-
-  wasm:
-    name: Wasm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: bytecodealliance/actions/wasmtime/setup@v1
-      - name: Install Swift and Swift SDK for WebAssembly
-        run: |
-          PREFIX=/opt/swift
-          set -ex
-          curl -f -o /tmp/swift.tar.gz "https://download.swift.org/swift-6.0.2-release/ubuntu2204/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE-ubuntu22.04.tar.gz"
-          sudo mkdir -p $PREFIX; sudo tar -xzf /tmp/swift.tar.gz -C $PREFIX --strip-component 1
-          $PREFIX/usr/bin/swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0.2-RELEASE/swift-wasm-6.0.2-RELEASE-wasm32-unknown-wasi.artifactbundle.zip --checksum 6ffedb055cb9956395d9f435d03d53ebe9f6a8d45106b979d1b7f53358e1dcb4
-          echo "$PREFIX/usr/bin" >> $GITHUB_PATH
-
-      - name: Build
-        run: swift build --target IssueReporting --swift-sdk wasm32-unknown-wasi -Xlinker -z -Xlinker stack-size=$((1024 * 1024))
-
-  # windows:
-  #   name: Windows
-  #   strategy:
-  #     matrix:
-  #       os: [windows-latest]
-  #       config:
-  #         - debug
-  #         - release
-  #     fail-fast: false
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: compnerd/gha-setup-swift@main
-  #       with:
-  #         branch: swift-6.0.3-release
-  #         tag: 6.0.3-RELEASE
-  #     - name: Set long paths
-  #       run: git config --system core.longpaths true
-  #     - uses: actions/checkout@v5
-  #     - name: Build
-  #       run: swift build -c ${{ matrix.config }}
-  #     - name: Run tests (debug only)
-  #       run: swift test
-
-  # android:
-  #   name: Android
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v5
-  #     - name: "Test Swift Package on Android"
-  #       uses: skiptools/swift-android-action@v2

--- a/Package.swift
+++ b/Package.swift
@@ -77,3 +77,15 @@ let package = Package(
     )
   )
 #endif
+
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(contentsOf: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("ImmutableWeakCaptures"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("MemberImportVisibility"),
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+  ])
+}

--- a/Sources/IssueReporting/Internal/SwiftTesting.swift
+++ b/Sources/IssueReporting/Internal/SwiftTesting.swift
@@ -1,5 +1,5 @@
 import Foundation
-import IssueReportingPackageSupport
+public import IssueReportingPackageSupport
 
 #if canImport(WinSDK)
   import WinSDK

--- a/Sources/IssueReporting/Internal/SwiftTesting.swift
+++ b/Sources/IssueReporting/Internal/SwiftTesting.swift
@@ -5,6 +5,13 @@ public import IssueReportingPackageSupport
   import WinSDK
 #endif
 
+// NB: We can drop this when we bump to swift-tools-version 6.2
+#if hasFeature(NonisolatedNonsendingByDefault)
+  public typealias _AsyncThrowingBody = @concurrent () async throws -> Void
+#else
+  public typealias _AsyncThrowingBody = () async throws -> Void
+#endif
+
 @usableFromInline
 func _recordIssue(
   message: String?,
@@ -233,7 +240,7 @@ func _withKnownIssue(
     filePath: String,
     line: Int,
     column: Int,
-    _ body: () async throws -> Void
+    _ body: _AsyncThrowingBody
   ) async {
     guard
       let function = function(for: "$s25IssueReportingTestSupport010_withKnownA13AsyncIsolatedypyF")
@@ -249,7 +256,6 @@ func _withKnownIssue(
           line: line,
           column: column
         )
-
         guard
           let withKnownIssue = unsafeBitCast(
             symbol: """
@@ -262,7 +268,7 @@ func _withKnownIssue(
               Bool,
               isolated (any Actor)?,
               SourceLocation,
-              () async throws -> Void
+              _AsyncThrowingBody
             ) async -> Void)
             .self
           )

--- a/Sources/IssueReporting/Internal/XCTest.swift
+++ b/Sources/IssueReporting/Internal/XCTest.swift
@@ -1,13 +1,15 @@
-#if _runtime(_ObjC)
-  public import Foundation
-#endif
+#if DEBUG
+  #if _runtime(_ObjC)
+    public import Foundation
+  #endif
 
-#if canImport(Darwin)
-  public import Darwin
-#elseif canImport(Glibc)
-  public import Glibc
-#elseif canImport(WinSDK)
-  public import WinSDK
+  #if canImport(Darwin)
+    public import Darwin
+  #elseif canImport(Glibc)
+    public import Glibc
+  #elseif canImport(WinSDK)
+    public import WinSDK
+  #endif
 #endif
 
 @usableFromInline

--- a/Sources/IssueReporting/Internal/XCTest.swift
+++ b/Sources/IssueReporting/Internal/XCTest.swift
@@ -1,13 +1,13 @@
 #if _runtime(_ObjC)
-  import Foundation
+  public import Foundation
 #endif
 
 #if canImport(Darwin)
-  import Darwin
+  public import Darwin
 #elseif canImport(Glibc)
-  import Glibc
+  public import Glibc
 #elseif canImport(WinSDK)
-  import WinSDK
+  public import WinSDK
 #endif
 
 @usableFromInline
@@ -63,7 +63,7 @@ func _XCTExpectFailure<R>(
         else { return try failingBlock() }
         if let pointer = dlsym(dlopen(nil, RTLD_NOW), "XCTExpectFailureWithOptionsInBlock"),
           let XCTExpectedFailureOptions = NSClassFromString("XCTExpectedFailureOptions")
-            as Any as? NSObjectProtocol,
+            as Any as? any NSObjectProtocol,
           let options = strict ?? true
             ? XCTExpectedFailureOptions
               .perform(NSSelectorFromString("alloc"))?.takeUnretainedValue()

--- a/Sources/IssueReporting/IssueReporters/DefaultReporter.swift
+++ b/Sources/IssueReporting/IssueReporters/DefaultReporter.swift
@@ -1,7 +1,7 @@
-import Foundation
+public import Foundation
 
 #if canImport(os)
-  import os
+  public import os
 #endif
 
 extension IssueReporter where Self == _DefaultReporter {

--- a/Sources/IssueReporting/TestContext.swift
+++ b/Sources/IssueReporting/TestContext.swift
@@ -1,3 +1,5 @@
+import IssueReportingPackageSupport
+
 /// A type representing the context in which a test is being run, _i.e._ either in Swift's native
 /// Testing framework, or Xcode's XCTest framework.
 public enum TestContext: Equatable, Sendable {

--- a/Sources/IssueReporting/Unimplemented.swift
+++ b/Sources/IssueReporting/Unimplemented.swift
@@ -137,7 +137,7 @@ public func unimplemented<each Argument, Result>(
   function: StaticString = #function,
   line: UInt = #line,
   column: UInt = #column
-) -> @Sendable (repeat each Argument) async -> Result {
+) -> @concurrent @Sendable (repeat each Argument) async -> Result {
   return { (argument: repeat each Argument) in
     _fail(
       description(),
@@ -174,7 +174,7 @@ public func unimplemented<each Argument, Result>(
   function: StaticString = #function,
   line: UInt = #line,
   column: UInt = #column
-) -> @Sendable (repeat each Argument) async throws -> Result {
+) -> @concurrent @Sendable (repeat each Argument) async throws -> Result {
   return { (argument: repeat each Argument) in
     let description = description()
     _fail(
@@ -216,7 +216,7 @@ public func unimplemented<each Argument, Result>(
     function: StaticString = #function,
     line: UInt = #line,
     column: UInt = #column
-  ) -> @Sendable (repeat each Argument) async throws(Failure) -> Result {
+  ) -> @concurrent @Sendable (repeat each Argument) async throws(Failure) -> Result {
     return { (argument: repeat each Argument) async throws(Failure) in
       let description = description()
       _fail(

--- a/Sources/IssueReporting/Unimplemented.swift
+++ b/Sources/IssueReporting/Unimplemented.swift
@@ -1,3 +1,26 @@
+// NB: We can drop this when we bump to swift-tools-version 6.2
+#if hasFeature(NonisolatedNonsendingByDefault)
+  public typealias _UnimplementedAsyncClosure<each Argument, Result> =
+    @concurrent @Sendable (repeat each Argument) async -> Result
+  public typealias _UnimplementedAsyncThrowingClosure<each Argument, Result> =
+    @concurrent @Sendable (repeat each Argument) async throws -> Result
+#else
+  public typealias _UnimplementedAsyncClosure<each Argument, Result> =
+    @Sendable (repeat each Argument) async -> Result
+  public typealias _UnimplementedAsyncThrowingClosure<each Argument, Result> =
+    @Sendable (repeat each Argument) async throws -> Result
+#endif
+
+#if compiler(>=6)
+  #if hasFeature(NonisolatedNonsendingByDefault)
+    public typealias _UnimplementedAsyncTypedThrowingClosure<each Argument, Failure: Error, Result> =
+      @concurrent @Sendable (repeat each Argument) async throws(Failure) -> Result
+  #else
+    public typealias _UnimplementedAsyncTypedThrowingClosure<each Argument, Failure: Error, Result> =
+      @Sendable (repeat each Argument) async throws(Failure) -> Result
+  #endif
+#endif
+
 /// Returns a closure that reports an issue when invoked.
 ///
 /// Useful for creating closures that need to be overridden by users of your API, and if it is
@@ -137,7 +160,7 @@ public func unimplemented<each Argument, Result>(
   function: StaticString = #function,
   line: UInt = #line,
   column: UInt = #column
-) -> @concurrent @Sendable (repeat each Argument) async -> Result {
+) -> _UnimplementedAsyncClosure<repeat each Argument, Result> {
   return { (argument: repeat each Argument) in
     _fail(
       description(),
@@ -174,7 +197,7 @@ public func unimplemented<each Argument, Result>(
   function: StaticString = #function,
   line: UInt = #line,
   column: UInt = #column
-) -> @concurrent @Sendable (repeat each Argument) async throws -> Result {
+) -> _UnimplementedAsyncThrowingClosure<repeat each Argument, Result> {
   return { (argument: repeat each Argument) in
     let description = description()
     _fail(
@@ -216,7 +239,7 @@ public func unimplemented<each Argument, Result>(
     function: StaticString = #function,
     line: UInt = #line,
     column: UInt = #column
-  ) -> @concurrent @Sendable (repeat each Argument) async throws(Failure) -> Result {
+  ) -> _UnimplementedAsyncTypedThrowingClosure<repeat each Argument, Failure, Result> {
     return { (argument: repeat each Argument) async throws(Failure) in
       let description = description()
       _fail(

--- a/Sources/IssueReporting/WithExpectedIssue.swift
+++ b/Sources/IssueReporting/WithExpectedIssue.swift
@@ -140,7 +140,7 @@ public func withExpectedIssue(
     filePath: StaticString = #filePath,
     line: UInt = #line,
     column: UInt = #column,
-    _ body: () async throws -> Void
+    _ body: _AsyncThrowingBody
   ) async {
     guard let context = TestContext.current else {
       guard !isTesting else { return }
@@ -212,7 +212,7 @@ public func withExpectedIssue(
     filePath: StaticString = #filePath,
     line: UInt = #line,
     column: UInt = #column,
-    _ body: () async throws -> Void
+    _ body: _AsyncThrowingBody
   ) async {
     guard let context = TestContext.current else {
       guard !isTesting else { return }

--- a/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
@@ -299,7 +299,7 @@ public func unimplemented<each Argument, Result>(
   fileID: StaticString = #fileID,
   function: StaticString = #function,
   line: UInt = #line
-) -> @concurrent @Sendable (repeat each Argument) async -> Result {
+) -> _UnimplementedAsyncClosure<repeat each Argument, Result> {
   return { (argument: repeat each Argument) in
     let description = description()
     _fail(
@@ -525,7 +525,7 @@ public func XCTUnimplemented<each Argument, Result>(
   filePath: StaticString = #filePath,
   function: StaticString = #function,
   line: UInt = #line
-) -> @concurrent @Sendable (repeat each Argument) async -> Result {
+) -> _UnimplementedAsyncClosure<repeat each Argument, Result> {
   unimplemented(
     description(),
     file: filePath,
@@ -542,7 +542,7 @@ public func XCTUnimplemented<each Argument, Result>(
   filePath: StaticString = #filePath,
   function: StaticString = #function,
   line: UInt = #line
-) -> @concurrent @Sendable (repeat each Argument) async -> Result {
+) -> _UnimplementedAsyncClosure<repeat each Argument, Result> {
   unimplemented(
     description(),
     file: filePath,
@@ -555,7 +555,7 @@ public func XCTUnimplemented<each Argument, Result>(
 @available(*, deprecated, renamed: "unimplemented")
 public func XCTUnimplemented<each Argument, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @concurrent @Sendable (repeat each Argument) async throws -> Result {
+) -> _UnimplementedAsyncThrowingClosure<repeat each Argument, Result> {
   unimplemented(description())
 }
 

--- a/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
+++ b/Sources/XCTestDynamicOverlay/Internal/Deprecations.swift
@@ -60,7 +60,7 @@ public var _XCTIsTesting: Bool {
     else { return try failingBlock() }
     guard
       let XCTExpectedFailureOptions = NSClassFromString("XCTExpectedFailureOptions")
-        as Any as? NSObjectProtocol,
+        as Any as? any NSObjectProtocol,
       let options = strict ?? true
         ? XCTExpectedFailureOptions
           .perform(NSSelectorFromString("alloc"))?.takeUnretainedValue()
@@ -90,7 +90,7 @@ public var _XCTIsTesting: Bool {
       to: (@convention(c) (String?, AnyObject, () -> Void) -> Void).self
     )
 
-    var result: Result<R, Error>!
+    var result: Result<R, any Error>!
     XCTExpectFailureWithOptionsInBlock(failureReason, options) {
       result = Result { try failingBlock() }
     }
@@ -130,7 +130,7 @@ public var _XCTIsTesting: Bool {
     else { return }
     guard
       let XCTExpectedFailureOptions = NSClassFromString("XCTExpectedFailureOptions")
-        as Any as? NSObjectProtocol,
+        as Any as? any NSObjectProtocol,
       let options = strict ?? true
         ? XCTExpectedFailureOptions
           .perform(NSSelectorFromString("alloc"))?.takeUnretainedValue()
@@ -233,7 +233,7 @@ public var XCTCurrentTestCase: AnyObject? {
   #if _runtime(_ObjC)
     guard
       let XCTestObservationCenter = NSClassFromString("XCTestObservationCenter"),
-      let XCTestObservationCenter = XCTestObservationCenter as Any as? NSObjectProtocol,
+      let XCTestObservationCenter = XCTestObservationCenter as Any as? any NSObjectProtocol,
       let shared = XCTestObservationCenter.perform(Selector(("sharedTestObservationCenter")))?
         .takeUnretainedValue(),
       let observers = shared.perform(Selector(("observers")))?
@@ -299,7 +299,7 @@ public func unimplemented<each Argument, Result>(
   fileID: StaticString = #fileID,
   function: StaticString = #function,
   line: UInt = #line
-) -> @Sendable (repeat each Argument) async -> Result {
+) -> @concurrent @Sendable (repeat each Argument) async -> Result {
   return { (argument: repeat each Argument) in
     let description = description()
     _fail(
@@ -349,7 +349,7 @@ private protocol _OptionalProtocol { static var none: Self { get } }
 extension Optional: _OptionalProtocol {}
 @available(*, deprecated)
 private func _optionalPlaceholder<Result>() throws -> Result {
-  if let result = (Result.self as? _OptionalProtocol.Type) {
+  if let result = (Result.self as? any _OptionalProtocol.Type) {
     return result.none as! Result
   }
   throw PlaceholderGenerationFailure()
@@ -358,7 +358,7 @@ private func _optionalPlaceholder<Result>() throws -> Result {
 @available(*, deprecated)
 private func _placeholder<Result>() -> Result? {
   switch Result.self {
-  case let type as _DefaultInitializable.Type: return type.placeholder as? Result
+  case let type as any _DefaultInitializable.Type: return type.placeholder as? Result
   case is Void.Type: return () as? Result
   case let type as any RangeReplaceableCollection.Type: return type.placeholder as? Result
   case let type as any AdditiveArithmetic.Type: return type.placeholder as? Result
@@ -444,7 +444,7 @@ extension AsyncStream: _DefaultInitializable {
 }
 
 @available(*, deprecated)
-extension AsyncThrowingStream: _DefaultInitializable where Failure == Error {
+extension AsyncThrowingStream: _DefaultInitializable where Failure == any Error {
   init() { self.init { $0.finish(throwing: CancellationError()) } }
 }
 
@@ -525,7 +525,7 @@ public func XCTUnimplemented<each Argument, Result>(
   filePath: StaticString = #filePath,
   function: StaticString = #function,
   line: UInt = #line
-) -> @Sendable (repeat each Argument) async -> Result {
+) -> @concurrent @Sendable (repeat each Argument) async -> Result {
   unimplemented(
     description(),
     file: filePath,
@@ -542,7 +542,7 @@ public func XCTUnimplemented<each Argument, Result>(
   filePath: StaticString = #filePath,
   function: StaticString = #function,
   line: UInt = #line
-) -> @Sendable (repeat each Argument) async -> Result {
+) -> @concurrent @Sendable (repeat each Argument) async -> Result {
   unimplemented(
     description(),
     file: filePath,
@@ -555,7 +555,7 @@ public func XCTUnimplemented<each Argument, Result>(
 @available(*, deprecated, renamed: "unimplemented")
 public func XCTUnimplemented<each Argument, Result>(
   _ description: @autoclosure @escaping @Sendable () -> String = ""
-) -> @Sendable (repeat each Argument) async throws -> Result {
+) -> @concurrent @Sendable (repeat each Argument) async throws -> Result {
   unimplemented(description())
 }
 

--- a/Tests/XCTestDynamicOverlayTests/XCTContextTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTContextTests.swift
@@ -2,7 +2,7 @@
   import XCTest
   import XCTestDynamicOverlay
 
-  public final class XCTContextTests: XCTestCase {
+  final class XCTContextTests: XCTestCase {
     func testContext() {
       XCTExpectFailure {
         $0.compactDescription == "failed - Failed"

--- a/Tests/XCTestDynamicOverlayTests/XCTExpectFailureTests.swift
+++ b/Tests/XCTestDynamicOverlayTests/XCTExpectFailureTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import XCTestDynamicOverlay
 
 #if canImport(ObjectiveC)
   final class XCTExpectFailureTests: XCTestCase {


### PR DESCRIPTION
This turns on all upcoming Swift features, bringing in changes from approachable concurrency, like `nonisolated(nonsending)`, and more.