### PR TITLE
Remove internal IssueReportingPackageSupport module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,13 +21,7 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "IssueReportingPackageSupport"
-    ),
-    .target(
-      name: "IssueReporting",
-      dependencies: [
-        "IssueReportingPackageSupport"
-      ]
+      name: "IssueReporting"
     ),
     .testTarget(
       name: "IssueReportingTests",
@@ -43,10 +37,7 @@ let package = Package(
       ]
     ),
     .target(
-      name: "IssueReportingTestSupport",
-      dependencies: [
-        "IssueReportingPackageSupport"
-      ]
+      name: "IssueReportingTestSupport"
     ),
     .target(
       name: "XCTestDynamicOverlay",

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -22,13 +22,7 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "IssueReportingPackageSupport"
-    ),
-    .target(
-      name: "IssueReporting",
-      dependencies: [
-        "IssueReportingPackageSupport"
-      ]
+      name: "IssueReporting"
     ),
     .testTarget(
       name: "IssueReportingTests",
@@ -44,10 +38,7 @@ let package = Package(
       ]
     ),
     .target(
-      name: "IssueReportingTestSupport",
-      dependencies: [
-        "IssueReportingPackageSupport"
-      ]
+      name: "IssueReportingTestSupport"
     ),
     .target(
       name: "XCTestDynamicOverlay",

--- a/Sources/IssueReporting/Internal/SwiftTesting.swift
+++ b/Sources/IssueReporting/Internal/SwiftTesting.swift
@@ -1,5 +1,4 @@
 import Foundation
-public import IssueReportingPackageSupport
 
 #if canImport(WinSDK)
   import WinSDK

--- a/Sources/IssueReporting/Symbolic Links/IssueReportingPackageSupport
+++ b/Sources/IssueReporting/Symbolic Links/IssueReportingPackageSupport
@@ -1,0 +1,1 @@
+../../IssueReportingPackageSupport

--- a/Sources/IssueReporting/TestContext.swift
+++ b/Sources/IssueReporting/TestContext.swift
@@ -1,5 +1,3 @@
-import IssueReportingPackageSupport
-
 /// A type representing the context in which a test is being run, _i.e._ either in Swift's native
 /// Testing framework, or Xcode's XCTest framework.
 public enum TestContext: Equatable, Sendable {

--- a/Sources/IssueReportingTestSupport/SwiftTesting.swift
+++ b/Sources/IssueReportingTestSupport/SwiftTesting.swift
@@ -1,5 +1,3 @@
-import IssueReportingPackageSupport
-
 #if canImport(Testing)
   import Testing
 #endif

--- a/Sources/IssueReportingTestSupport/Symbolic Links/IssueReportingPackageSupport
+++ b/Sources/IssueReportingTestSupport/Symbolic Links/IssueReportingPackageSupport
@@ -1,0 +1,1 @@
+../../IssueReportingPackageSupport


### PR DESCRIPTION
It can cause strange warnings downstream, but we don't need the target. We can use symlinks to share the code across targets instead.

Fixes #179.