### PR TITLE
Detect Bazel swift_test in isTesting

### DIFF
--- a/Sources/IssueReporting/IsTesting.swift
+++ b/Sources/IssueReporting/IsTesting.swift
@@ -5,6 +5,9 @@
 
   /// Whether or not the current process is running tests.
   ///
+  /// This detects tests hosted by Xcode/XCTest, SwiftPM (`swift test`), and Bazel (`swift_test`,
+  /// including Swift Testing) across Apple platforms and Linux.
+  ///
   /// You can use this information to prevent application code from running when hosting tests. For
   /// example, you can wrap your app entry point:
   ///
@@ -31,6 +34,15 @@
       if environment.keys.contains("XCTestBundleInjectPath") { return true }
       if environment.keys.contains("XCTestConfigurationFilePath") { return true }
       if environment.keys.contains("XCTestSessionIdentifier") { return true }
+
+      // Bazel sets these environment variables for every 'bazel test' run, on all platforms
+      // (Linux and Apple) and regardless of the test framework (XCTest, Swift Testing, or a
+      // custom 'swift_test' binary). Bazel's "test encyclopedia" guarantees that 'BAZEL_TEST'
+      // and 'TEST_SRCDIR' are present for test executables. Note that, because these are
+      // inherited by child processes, a non-test process spawned by a Bazel test will also be
+      // detected as testing, which matches how the 'XCTest*' variables above behave.
+      if environment.keys.contains("BAZEL_TEST") { return true }
+      if environment.keys.contains("TEST_SRCDIR") { return true }
 
       return arguments.contains { argument in
         let path = URL(fileURLWithPath: argument)

--- a/Sources/IssueReporting/IsTesting.swift
+++ b/Sources/IssueReporting/IsTesting.swift
@@ -31,7 +31,6 @@
       if environment.keys.contains("XCTestBundleInjectPath") { return true }
       if environment.keys.contains("XCTestConfigurationFilePath") { return true }
       if environment.keys.contains("XCTestSessionIdentifier") { return true }
-
       if environment.keys.contains("BAZEL_TEST") { return true }
 
       return arguments.contains { argument in

--- a/Sources/IssueReporting/IsTesting.swift
+++ b/Sources/IssueReporting/IsTesting.swift
@@ -5,9 +5,6 @@
 
   /// Whether or not the current process is running tests.
   ///
-  /// This detects tests hosted by Xcode/XCTest, SwiftPM (`swift test`), and Bazel (`swift_test`,
-  /// including Swift Testing) across Apple platforms and Linux.
-  ///
   /// You can use this information to prevent application code from running when hosting tests. For
   /// example, you can wrap your app entry point:
   ///
@@ -35,14 +32,7 @@
       if environment.keys.contains("XCTestConfigurationFilePath") { return true }
       if environment.keys.contains("XCTestSessionIdentifier") { return true }
 
-      // Bazel sets these environment variables for every 'bazel test' run, on all platforms
-      // (Linux and Apple) and regardless of the test framework (XCTest, Swift Testing, or a
-      // custom 'swift_test' binary). Bazel's "test encyclopedia" guarantees that 'BAZEL_TEST'
-      // and 'TEST_SRCDIR' are present for test executables. Note that, because these are
-      // inherited by child processes, a non-test process spawned by a Bazel test will also be
-      // detected as testing, which matches how the 'XCTest*' variables above behave.
       if environment.keys.contains("BAZEL_TEST") { return true }
-      if environment.keys.contains("TEST_SRCDIR") { return true }
 
       return arguments.contains { argument in
         let path = URL(fileURLWithPath: argument)


### PR DESCRIPTION
## Motivation

`isTesting` did not detect tests run via Bazel's [`swift_test`](https://github.com/bazelbuild/rules_swift) rule (rules_swift), including those using Swift Testing.

Unlike SwiftPM and Xcode, Bazel builds a standard executable that runs the testing frameworks **in-process**, so none of the existing signals are present at runtime:

- No `XCTest*` environment variables (those are set by Xcode's test runner).
- No `--testing-library` / `swiftpm-testing-helper` arguments (Bazel drives Swift Testing in-process via `dlsym`, not a helper process).
- On macOS the binary is `…/Foo.xctest/Contents/MacOS/Foo`, where `.xctest` is only a *middle* path component, so `URL.pathExtension`/`lastPathComponent` never match it.

As a result `isTesting` was `false` under Bazel, which also disabled `TestContext.current` (it is gated on `isTesting`), so issue reporting did not route to the test framework.

## Approach

Detect Bazel's standard test environment variables. Per Bazel's [test encyclopedia](https://bazel.build/reference/test-encyclopedia), `BAZEL_TEST` and `TEST_SRCDIR` are **required** to be present for every `bazel test` execution. They are set by Bazel's core test runner (not the toolchain), so they cover XCTest, Swift Testing, and custom `swift_test` binaries identically — on **both Linux and Apple platforms**.

A plain `bazel run` of a non-test binary has neither variable set, so this does not introduce false positives for normal execution.

## Verification

- SwiftPM `swift build` + `swift test`: clean, all suites pass.
- A real Bazel `swift_test` (Bazel 9.1.1, rules_swift) compiling this module asserts `isTesting == true` and `TestContext.current?.isSwiftTesting == true`; inverting the assertion produces a genuine failure (ruling out a false pass from zero discovered tests).
- A plain `bazel run` binary reports `isTesting == false`.

## Note

Bazel's test environment variables are inherited by child processes, so a non-test process spawned by a Bazel test is also detected as testing. This matches the existing behavior of the `XCTest*` variables and is documented in a code comment.