### PR TITLE
Support issue reporting on Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,10 @@ jobs:
         run: make test-${{ matrix.config }}
       - name: Build for static-stdlib
         run: make CONFIG=${{ matrix.config }} build-for-static-stdlib
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: skiptools/swift-android-action@v2
+        with:
+          free-disk-space: true

--- a/Sources/IssueReporting/Internal/SwiftTesting.swift
+++ b/Sources/IssueReporting/Internal/SwiftTesting.swift
@@ -678,16 +678,7 @@ func function(for symbol: String) -> Any? {
 
 @usableFromInline
 func unsafeBitCast<F>(symbol: String, in library: String, to function: F.Type) -> F? {
-  #if os(Linux)
-    guard
-      let handle = dlopen("lib\(library).so", RTLD_LAZY),
-      let pointer = dlsym(handle, symbol)
-    else { return nil }
-    return unsafeBitCast(pointer, to: F.self)
-  #elseif os(Android)
-    // Android is ELF + `dlopen` like Linux, but `os(Linux)` is false here. The test-support
-    // symbols may live in a separate `.so` (dynamic linking) or in the test executable itself
-    // (static linking), so try the named library first and fall back to the main program handle.
+  #if os(Linux) || os(Android)
     guard
       let handle = dlopen("lib\(library).so", RTLD_LAZY) ?? dlopen(nil, RTLD_LAZY),
       let pointer = dlsym(handle, symbol)

--- a/Sources/IssueReporting/Internal/SwiftTesting.swift
+++ b/Sources/IssueReporting/Internal/SwiftTesting.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+#if canImport(Android)
+  import Android  // dlopen/dlsym/RTLD_LAZY on Android (not re-exported by Foundation as on Linux)
+#endif
+
 #if canImport(WinSDK)
   import WinSDK
 #endif
@@ -677,6 +681,15 @@ func unsafeBitCast<F>(symbol: String, in library: String, to function: F.Type) -
   #if os(Linux)
     guard
       let handle = dlopen("lib\(library).so", RTLD_LAZY),
+      let pointer = dlsym(handle, symbol)
+    else { return nil }
+    return unsafeBitCast(pointer, to: F.self)
+  #elseif os(Android)
+    // Android is ELF + `dlopen` like Linux, but `os(Linux)` is false here. The test-support
+    // symbols may live in a separate `.so` (dynamic linking) or in the test executable itself
+    // (static linking), so try the named library first and fall back to the main program handle.
+    guard
+      let handle = dlopen("lib\(library).so", RTLD_LAZY) ?? dlopen(nil, RTLD_LAZY),
       let pointer = dlsym(handle, symbol)
     else { return nil }
     return unsafeBitCast(pointer, to: F.self)

--- a/Sources/IssueReporting/Internal/SwiftTesting.swift
+++ b/Sources/IssueReporting/Internal/SwiftTesting.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 #if canImport(Android)
-  import Android  // dlopen/dlsym/RTLD_LAZY on Android (not re-exported by Foundation as on Linux)
+  import Android
 #endif
 
 #if canImport(WinSDK)


### PR DESCRIPTION
## Motivation

On Android, `reportIssue` — and everything built on it (`unimplemented`, `swift-dependencies`' test-failure recording, etc.) — never records a test failure. It prints:

> A failure was recorded without linking the XCTest framework … To fix this, add "IssueReportingTestSupport" as a dependency to your test target.

…even with `IssueReportingTestSupport` linked, and the test passes regardless. So issues are silently dropped on Android.

## Cause

`unsafeBitCast(symbol:in:to:)` in `Sources/IssueReporting/Internal/SwiftTesting.swift` — the `dlopen`/`dlsym` shim that loads the `IssueReportingTestSupport` / `Testing` bridge symbols — only has a `dlopen` path under `#if os(Linux)`. On Android, `os(Linux)` is `false` (it's `os(Android)`), so it falls through to `#else return nil`; the symbols are never found and recording degrades to the print-only fallback.

## Fix

Treat Android the same way as Linux: with ELF + `dlopen`:

- Add an `os(Android)` branch to the shim and, if `dlopen("lib<library>.so")` fails, falls back to `dlopen(nil)` (the main program). This way it works whether the support library is linked dynamically (`.so`) or statically into the test executable.
- `import Android` so `dlopen` / `dlsym` / `RTLD_LAZY` are in scope (Foundation re-exports the C library on Linux but not on Android).

## Verification

Built and ran a swift-testing suite on an aarch64 Android device (Swift Android SDK). Before: unimplemented-dependency accesses printed the "without linking" warning and the run passed. After: the same accesses are recorded as issues and the run fails, correctly attributed to the offending tests.