### PR TITLE
docs: point `getting started` to the rendered documentation page on SPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ that ship in the same target as the library itself.
 
 IssueReporting comes with a number of reporters, custom reporting functionality, and more. To learn
 about these features, see
-[Getting started](Sources/IssueReporting/Documentation.docc/Articles/GettingStarted.md).
+[Getting started](https://swiftpackageindex.com/pointfreeco/swift-issue-reporting/main/documentation/issuereporting).
 
 ## Case studies
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ that ship in the same target as the library itself.
 
 IssueReporting comes with a number of reporters, custom reporting functionality, and more. To learn
 about these features, see
-[Getting started](https://swiftpackageindex.com/pointfreeco/swift-issue-reporting/main/documentation/issuereporting).
+[Getting started](https://swiftpackageindex.com/pointfreeco/swift-issue-reporting/main/documentation/issuereporting/gettingstarted).
 
 ## Case studies
 


### PR DESCRIPTION
- Images resources were broken. Fixed pointing to the relative location.
- Also, added native md light/dark mode support for images.

Please double check the changes.
Thanks 